### PR TITLE
Fix broken test on STAGING_DIR

### DIFF
--- a/package_sprint.sh
+++ b/package_sprint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -e
+
+set -o errexit
+set -o pipefail
+set -o nounset
 
 # This script creates a package of artifacts that can then be used at a code sprint working on Drupal 8.
 # It assumes it's being run in teh repository root.

--- a/package_sprint.sh
+++ b/package_sprint.sh
@@ -22,7 +22,7 @@ OS=$(uname)
 BINOWNER=$(ls -ld /usr/local/bin | awk '{print $3}')
 USER=$(whoami)
 
-if [ -d "$STAGING_DIR" ] && [ ! -z "$(ls -A \"$STAGING_DIR\")" ] ; then
+if [ -d "$STAGING_DIR" ] && [ ! -z "$(ls -A "$STAGING_DIR")" ] ; then
 	echo -n "The staging directory already has files. Do you want to continue (y/n)? "
 	read answer
 	if echo "$answer" | grep -iq "^y"; then

--- a/package_sprint.sh
+++ b/package_sprint.sh
@@ -10,7 +10,6 @@ set -o nounset
 STAGING_DIR_NAME=drupal_sprint_package
 STAGING_DIR_BASE=~/tmp
 STAGING_DIR=$STAGING_DIR_BASE/$STAGING_DIR_NAME
-FINAL_TARGET_DIR=/tmp
 REPO_DIR=$PWD
 
 
@@ -128,4 +127,4 @@ popd
 cd $STAGING_DIR_BASE
 tar -czf drupal_sprint_package.tar.gz $STAGING_DIR_NAME
 zip -r -q drupal_sprint_package.zip $STAGING_DIR_NAME
-printf "${GREEN}The sprint tarballs and zipballs are in $(ls $FINAL_TARGET_DIR/drupal_sprint_package*).${RESET}\n"
+printf "${GREEN}The sprint tarballs and zipballs are in $(ls $STAGING_DIR_BASE/drupal_sprint_package.*).${RESET}\n"


### PR DESCRIPTION
There was a test on $STAGING_DIR which inexplicably had too much quoting, this fixes it.

Also, this script shouldn't have been able to run due to this error, so added

set -o errexit
set -o pipefail
set -o nounset
