### PR TITLE
Adds licenses for 7-zip, alpine-cloud9 and linuxserver/thelounge docker images

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,20 +2,22 @@ This Software is distributed in a compressed archive with the following third-pa
 
   ddev is included in the distributable release as a software artifact, and is distributed under the Apache 2.0 license:
 
-    ddev - (c) Copyright 2016 DRUD Technology, LLC
+    ddev - (c) Copyright 2016 DRUD Technology, LLC.
 
   Docker™ images are included in the distributable release as software artifacts and distributed according to the provisions of the MIT license:
 
-    mailhog/mailhog - (c) Copyright 2014 - 2017 Ian Kent (http://iankent.uk)
+    mailhog/mailhog - (c) Copyright 2014 - 2017 Ian Kent (http://iankent.uk).
 
   Docker images are included in the distributable release as software artifacts and distributed according to the provisions of the Apache 2.0 license:
 
-    drud/ddev-router - (c) Copyright 2016 DRUD Technology, LLC
-    drud/docker-phpmyadmin - (c) Copyright 2017 DRUD Technology, LLC
-    drud/mariadb-local - (c) Copyright 2016 DRUD Technology, LLC
-    drud/nginx-php-fpm-local - (c) Copyright 2017 DRUD Technology, LLC
+    drud/ddev-router - (c) Copyright 2016 DRUD Technology, LLC.
+    drud/docker-phpmyadmin - (c) Copyright 2017 DRUD Technology, LLC.
+    drud/mariadb-local - (c) Copyright 2016 DRUD Technology, LLC.
+    drud/nginx-php-fpm-local - (c) Copyright 2017 DRUD Technology, LLC.
+    briangilbert/cloud9-alpine - (c) Copyright 2017 by the original authors.
+    linuxserver/thelounge - (c) Copyright 2016 by the original authors.
 
- Drupal™ is included in the distributable release as a software artifact, and is distributed under the GPL license:
+  Drupal™ is included in the distributable release as a software artifact, and is distributed under the GPL license:
 
     Drupal - (c) Copyright 2001 - 2013 by the original authors
       See drupal/core/COPYRIGHT.txt for more details.
@@ -28,3 +30,7 @@ This Software may be distributed alongside the following third-party software un
     Docker open source - (c) 2013 - 2017 Docker, Inc.
       See https://www.docker.com/components-licenses for more details.
       The trademark "Docker" belongs to Docker, Inc.
+
+  7-Zip is distributed under the GNU Lesser General Public License 2.1 license under the following copyright:
+
+    7-Zip Copyright (C) 1999-2018 Igor Pavlov.

--- a/licenses/LICENSE-7zip.txt
+++ b/licenses/LICENSE-7zip.txt
@@ -1,0 +1,91 @@
+  7-Zip
+  ~~~~~
+  License for use and distribution
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  7-Zip Copyright (C) 1999-2018 Igor Pavlov.
+
+  The licenses for files are:
+
+    1) 7z.dll:
+         - The "GNU LGPL" as main license for most of the code
+         - The "GNU LGPL" with "unRAR license restriction" for some code
+         - The "BSD 3-clause License" for some code
+    2) All other files: the "GNU LGPL".
+
+  Redistributions in binary form must reproduce related license information from this file.
+
+  Note:
+    You can use 7-Zip on any computer, including a computer in a commercial
+    organization. You don't need to register or pay for 7-Zip.
+
+
+  GNU LGPL information
+  --------------------
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You can receive a copy of the GNU Lesser General Public License from
+    http://www.gnu.org/
+
+
+
+
+  BSD 3-clause License
+  --------------------
+
+    The "BSD 3-clause License" is used for the code in 7z.dll that implements LZFSE data decompression.
+    That code was derived from the code in the "LZFSE compression library" developed by Apple Inc,
+    that also uses the "BSD 3-clause License":
+
+    ----
+    Copyright (c) 2015-2016, Apple Inc. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1.  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+    2.  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+        in the documentation and/or other materials provided with the distribution.
+
+    3.  Neither the name of the copyright holder(s) nor the names of any contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    ----
+
+
+
+
+  unRAR license restriction
+  -------------------------
+
+    The decompression engine for RAR archives was developed using source
+    code of unRAR program.
+    All copyrights to original unRAR code are owned by Alexander Roshal.
+
+    The license for original unRAR code has the following restriction:
+
+      The unRAR sources cannot be used to re-create the RAR compression algorithm,
+      which is proprietary. Distribution of modified unRAR sources in separate form
+      or as a part of other software is permitted, provided that it is clearly
+      stated in the documentation and source comments that the code may
+      not be used to develop a RAR (WinRAR) compatible archiver.
+
+
+  --
+  Igor Pavlov
+


### PR DESCRIPTION
Adds more licenses as a follow-up from Brian's PR.

I added full stops to the end of the copyright statements that I originally wrote.
