### PR TITLE
Fixes for v0.0.6 release

### DIFF
--- a/MAINTAINER_README.md
+++ b/MAINTAINER_README.md
@@ -4,7 +4,7 @@ Quicksprint is a basic toolkit to get people started with ddev and a Drupal code
 
 There are two parts to this project:
 
-1. A build of the tarball that a sprint attendee needs (done by a maintainer, who should be reading this right now). The maintainer uses package_drupal_script.sh to create a tarball/zipball for sprint attendees to use.
+1. A build of the tarball that a sprint attendee needs (done by a maintainer using Linux or Mac OS, who should be reading this right now). The maintainer uses package_drupal_script.sh to create a tarball/zipball for sprint attendees to use.
 2. A released tarball/zipball that has everything ready for an ordinary sprint user to get set up fast. It includes a SPRINTUSER_README.md to help them know what to do.
 
 Quicksprint uses [DDEV-Local](https://github.com/drud/ddev), docker, and a cloned Drupal8 repository to provide the tools to get people going quickly at a sprint.

--- a/MAINTAINER_README.md
+++ b/MAINTAINER_README.md
@@ -9,7 +9,7 @@ There are two parts to this project:
 
 Quicksprint uses [DDEV-Local](https://github.com/drud/ddev), docker, and a cloned Drupal8 repository to provide the tools to get people going quickly at a sprint.
 
-* To create a sprint package, run the script package_drupal_script.sh. (You can also retrieve a tarball or zipball of the results at https://github.com/drud/quicksprint/releases instead of doing this step.)
+* To create a sprint package you will need Docker running, then run the script package_drupal_script.sh. (You can also retrieve a tarball or zipball of the results at https://github.com/drud/quicksprint/releases instead of doing this step.)
 * Your users will then download and unarchive the tarball or zipball.
 * Linux and Mac users run install_ddev.sh, Windows users run install_ddev.cmd inside the directory created by the tarball.
 * After installation, Linux and Mac users can start up an instance by cd'ing to ~/Sites/sprint and running start_sprint.sh. Windows users run start_sprint.cmd in Sites/sprint of their user folder.

--- a/SPRINTUSER_README.md
+++ b/SPRINTUSER_README.md
@@ -13,8 +13,10 @@ Prerequisites:
 
 Installation and Startup:
 
-1. Install docker-ce if you don't already have it. (macOS and Windows): There are install images in the docker_installs directory of this folder.  (Linux) See [Linux instructions](https://docs.docker.com/install/#docker-ce)
+1. Install docker-ce if you don't already have it. (macOS and Windows): There may be a docker_installs directory in this folder with images.  (Linux) See [Linux instructions](https://docs.docker.com/install/#docker-ce)
 2. Start docker (it must be running to install ddev)
-3. Install DDEV-Local. (macOS/Linux): Run install_ddev.sh in the directory where this SPRINTUSER_README.md is with `./install_ddev.sh`; (Windows): run `install_ddev.cmd`.
-4. Start up Drupal 8: (macOS/Linux): cd to `~/Sites/sprint` and run `./start_sprint.sh` - (Windows): run `start_sprint.cmd` in `%userprofile%\Sites\sprint`
-5. _Windows users must run an additional command_: the start_clean command will tell you what the command is.
+3. Open docker preferences and set docker memory allocation to 3.0GB in the Advanced section (required for container to be started)
+3. Install DDEV-Local. (macOS/Linux): Run install_ddev.sh via terminal from the directory where this SPRINTUSER_README.md is with `./install_ddev.sh`; (Windows): run `install_ddev.cmd`.
+4. Create instance to use during sprint: (macOS/Linux): cd to `~/Sites/sprint` and run `./start_sprint.sh` - (Windows): run `start_sprint.cmd` in `%userprofile%\Sites\sprint`
+5. Follow prompts ffrom output of step 4 to start your Drupal 8 site.
+6. _Windows users must run an additional command_: the start_clean command will tell you what the command is.

--- a/install_ddev.cmd
+++ b/install_ddev.cmd
@@ -27,15 +27,26 @@ PAUSE
 
 cd %~dp0
 
-SET /p docker="Do you need to install Docker for Windows? [y/n]: " %=%
-IF %docker% == y (
-  REM Install Docker for Windows.
-  "docker_installs\Docker^%20for^%20Windows^%20Installer.exe" 
-  ECHO Once Docker installation is complete, 
-  ECHO Open Docker preferances and increase memory allocation to 3.0GiB.
-  ECHO Wait for Docker to restart before continuing.
-  ECHO Hit any key once complete.
+FOR %%X in (docker.exe) do (set FOUND=%%~$PATH:X)
+IF defined FOUND 
+  ECHO ######
+  ECHO # Docker found!
+  ECHO #
+  ECHO # Open Docker preferences, confirm the memory allocation is set to 3.0 GiB
+  ECHO # on the Advanced tab, and that docker has fully restarted before continuing.
+  ECHO #
+  ECHO # Hit any key once Docker has restarted.
+  ECHO ######
   PAUSE
+) ELSE (
+  ECHO ######
+  ECHO # You need to install Docker and have it running before executing this script.
+  ECHO #
+  ECHO # The installer is likely provided in a docker_installs directory with this package.
+  ECHO # Otherwise get it at https://docs.docker.com/docker-for-windows/release-notes/
+  ECHO #
+  ECHO ######
+  EXIT
 )
 
 ECHO "Installing docker images for ddev to use..."

--- a/install_ddev.cmd
+++ b/install_ddev.cmd
@@ -28,9 +28,9 @@ PAUSE
 cd %~dp0
 
 FOR %%X in (docker.exe) do (set FOUND=%%~$PATH:X)
-IF defined FOUND 
+IF defined FOUND
   ECHO ######
-  ECHO # Docker found!
+  ECHO # Docker found! Make sure it's running before continuing.
   ECHO #
   ECHO # Open Docker preferences, confirm the memory allocation is set to 3.0 GiB
   ECHO # on the Advanced tab, and that docker has fully restarted before continuing.

--- a/install_ddev.cmd
+++ b/install_ddev.cmd
@@ -30,7 +30,7 @@ cd %~dp0
 FOR %%X in (docker.exe) do (set FOUND=%%~$PATH:X)
 IF defined FOUND
   ECHO ######
-  ECHO # Docker found! Make sure it's running before continuing.
+  ECHO # Docker found! Make sure it's version 18.03.0 and running before continuing.
   ECHO #
   ECHO # Open Docker preferences, confirm the memory allocation is set to 3.0 GiB
   ECHO # on the Advanced tab, and that docker has fully restarted before continuing.

--- a/install_ddev.cmd
+++ b/install_ddev.cmd
@@ -42,7 +42,7 @@ IF defined FOUND
   ECHO ######
   ECHO # You need to install Docker and have it running before executing this script.
   ECHO #
-  ECHO # The installer is likely provided in a docker_installs directory with this package.
+  ECHO # The installer may be provided with this package.
   ECHO # Otherwise get it at https://docs.docker.com/docker-for-windows/release-notes/
   ECHO #
   ECHO ######

--- a/install_ddev.cmd
+++ b/install_ddev.cmd
@@ -4,6 +4,15 @@ CLS
 
 set CURRENT_DIR=%CD%
 
+REM check processs is running, via https://stackoverflow.com/a/1329790
+tasklist /FI "IMAGENAME eq Docker.exe" 2>NUL | find /I /N "Docker.exe">NUL
+if %ERRORLEVEL%==0
+  ECHO Docker is running, lets continue.
+) ELSE (
+  ECHO Docker isn't running and is required for this script, exiting.
+  EXIT
+)
+
 ECHO ####
 ECHO # This script will install everything you need to participate in this sprint.
 ECHO #

--- a/install_ddev.cmd
+++ b/install_ddev.cmd
@@ -89,6 +89,9 @@ ECHO # Your ddev and the sprint kit are now ready to use,
 ECHO # execute the following commands now to start:
 ECHO #
 ECHO # cd %userprofile%\Sites\sprint
+ECHO #
+ECHO # Right click and run the following as administrator from explorer.
+ECHO #
 ECHO # start_sprint.cmd
 ECHO #
 ECHO ######

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o errexit
+set -o pipefail
+set -o nounset
+
 clear
 
 # Install provided ddev release

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -58,7 +58,7 @@ if [[ "$OS" == "Darwin" ]]; then
         ${RED}
         ####
         # You need to install Docker and have it running before executing this script.
-        # The installer is likely provided in a docker_installs directory with this package.
+        # The installer may be provided with this package.
         # Otherwise get it at https://docs.docker.com/docker-for-mac/release-notes/
         ####
         ${RESET}"

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -50,37 +50,22 @@ if [[ "$OS" == "Darwin" ]]; then
 
     if ! command -v docker >/dev/null 2>&1; then
         printf "
-        ${GREEN}
+        ${RED}
         ####
-        # Installing docker so that ddev will work.
-        #
-        # Press y to continue
-        # !!You don't need to hit enter!!.
-        #
+        # You need to install Docker and have it running before executing this script.
+        # The installer is likely provided in a docker_installs directory with this package.
+        # Otherwise get it at https://docs.docker.com/docker-for-mac/release-notes/
         ####
         ${RESET}"
-        read -n1 SEVEN
-        if [[ ! $SEVEN =~ ^[Yy]$ ]]
-        then
-            exit 1
-        fi
-
-        echo ""
-        # Install and open Docker
-        hdiutil attach -nobrowse "${CURRENT_DIR}/docker_installs/Docker.dmg"
-        sleep 10
-        cp -rp /Volumes/Docker/Docker.app /Applications/
-        wait
-        open -a /Applications/Docker.app
-        hdiutil detach /Volumes/Docker
-
+        exit 1
+    else
         printf "
         ${GREEN}
         ####
-        # Please open Docker preferences and set Memory to 3.0 GiB on the Advanced tab.
-        # Wait for Docker to restart before continuing.
+        # ${YELLOW}Open Docker preferences, confirm the memory allocation is set to 3.0 GiB${GREEN}
+        # ${YELLOW}on the Advanced tab, and that docker has fully restarted before continuing.${GREEN}
         #
-        # Press y once this is done.
+        # Press y once Docker has restarted.
         # !!You don't need to hit enter!!.
         #
         ####
@@ -104,9 +89,9 @@ elif [[ "$OS" == "Linux" ]]; then
         printf "${YELLOW}Docker Compose is required for ddev. Download and install docker-compose at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
         printf "${YELLOW}See the Docker CE section at this page for linux installation instructions https://docs.docker.com/install/#server${RESET}\n"
     fi
-    
+
 else
-    printf "${RED}Sorry, this installer does not support your platform at this time.${RESET}\n"    
+    printf "${RED}Sorry, this installer does not support your platform at this time.${RESET}\n"
     exit 1
 fi
 

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -33,13 +33,14 @@ ${GREEN}
 #    -Cloud9 IDE
 #    -Thelounge IRC client
 #
-# Press y to continue
+# Press y to continue, or any other key to exit the script.
 # !!You don't need to hit enter!!.
 ####
 ${RESET}"
 read -n1 INSTALL
 if [[ ! $INSTALL =~ ^[Yy]$ ]]
 then
+    printf "${RED}You didn't hit y or Y, exiting script${RESET}"
     exit 1
 fi
 
@@ -65,7 +66,7 @@ if [[ "$OS" == "Darwin" ]]; then
         # ${YELLOW}Open Docker preferences, confirm the memory allocation is set to 3.0 GiB${GREEN}
         # ${YELLOW}on the Advanced tab, and that docker has fully restarted before continuing.${GREEN}
         #
-        # Press y once Docker has restarted.
+        # Press y once Docker has restarted, or any other key to exit the script.
         # !!You don't need to hit enter!!.
         #
         ####
@@ -73,6 +74,7 @@ if [[ "$OS" == "Darwin" ]]; then
         read -n1 DOCKMEM
         if [[ ! $DOCKMEM =~ ^[Yy]$ ]]
         then
+            printf "${RED}You didn't hit y or Y, exiting script${RESET}"
             exit 1
         fi
     fi
@@ -125,12 +127,13 @@ else
     sudo mv /tmp/ddev /usr/local/bin/
 fi
 
-if which brew &&  [ -f `brew --prefix`/etc/bash_completion ]; then
-    bash_completion_dir=$(brew --prefix)/etc/bash_completion.d
-    cp /tmp/ddev_bash_completion.sh $bash_completion_dir/ddev
-    printf "${GREEN}Installed ddev bash completions in $bash_completion_dir${RESET}\n"
-    rm /tmp/ddev_bash_completion.sh
+# Ensure ddev is in path
+if [[ ! $PATH = *"usr/local/bin"* ]]; then
+    echo "export PATH=/usr/local/bin:$PATH" >> ~/.bash_profile
+    echo "export PATH=/usr/local/bin:$PATH" >> ~/.zshrc
+    source ~/.bash_profile
 fi
+
 
 mkdir -p ~/Sites/sprint
 cp start_sprint.sh ~/Sites/sprint/
@@ -141,7 +144,7 @@ printf "
 ${GREEN}
 ######
 #
-# Your ddev and the sprint kit are now ready to use, 
+# Your ddev and the sprint kit are now ready to use,
 # execute the following commands now to start:
 #
 # ${YELLOW}cd ~/Sites/sprint${GREEN}

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -18,6 +18,16 @@ SHACMD=""
 FILEBASE=""
 CURRENT_DIR=$PWD
 
+# Check Docker is running
+SERVICE='docker'
+if ps ax | grep -v grep | grep -v /Library/PrivilegedHelperTools/com.docker.vmnetd | grep $SERVICE > /dev/null
+then
+    printf "${GREEN}$SERVICE service running, continuing.\n${RESET}"
+else
+    printf "${RED}Docker is not running and is required for this script, exiting.\n${RESET}"
+    exit 1
+fi
+
 #Explain what the script does
 printf "
 ${GREEN}

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -67,7 +67,7 @@ if [[ "$OS" == "Darwin" ]]; then
         printf "
         ${GREEN}
         ####
-        # ${YELLOW}Open Docker preferences, confirm the memory allocation is set to 3.0 GiB${GREEN}
+        # ${YELLOW}Open Docker preferences, confirm its version 18.03.0 and the memory allocation is set to 3.0 GiB${GREEN}
         # ${YELLOW}on the Advanced tab, and that docker has fully restarted before continuing.${GREEN}
         #
         # Press y once Docker has restarted, or any other key to exit the script.

--- a/package_additions.sh
+++ b/package_additions.sh
@@ -3,7 +3,16 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RESET='\033[0m'
+
 # Create archive with docker additions for sprint (IDE and IRC).
-docker pull briangilbert/cloud9-alpine:20180318 
+docker pull briangilbert/cloud9-alpine:20180318
 docker pull linuxserver/thelounge:94
+printf "${GREEN}#####
+# Compressing images.
+# This can take a while.
+#####${RESET}"
 docker save briangilbert/cloud9-alpine:20180318 linuxserver/thelounge:94 | xz -z -9e > $STAGING_DIR/ddev_tarballs/docker_additions.tar.xz

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -31,8 +31,14 @@ BINOWNER=$(ls -ld /usr/local/bin | awk '{print $3}')
 USER=$(whoami)
 
 if [ -d "$STAGING_DIR" ] && [ ! -z "$(ls -A "$STAGING_DIR")" ] ; then
-    echo -n "The staging directory already has files. Deleting them and recreating everything."
+    printf "${RED}The staging directory already has files. Deleting them and recreating everything.${RESET}"
     rm -rf $STAGING_DIR
+    if [ -e $STAGING_DIR_BASE/drupal_sprint_package$QUICKSPRINT_RELEASE.tar.gz ] ; then
+        rm $STAGING_DIR_BASE/drupal_sprint_package$QUICKSPRINT_RELEASE.tar.gz
+    fi
+    if [ -e $STAGING_DIR_BASE/drupal_sprint_package$QUICKSPRINT_RELEASE.zip ]; then
+        rm $STAGING_DIR_BASE/drupal_sprint_package$QUICKSPRINT_RELEASE.zip
+    fi
 fi
 
 SHACMD=""
@@ -64,6 +70,8 @@ if ! docker --version >/dev/null 2>&1; then
     printf "${YELLOW}Docker is required to use this package. Download and install docker at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
 fi
 
+cd $STAGING_DIR
+
 printf "
 ${GREEN}
 ####
@@ -72,24 +80,25 @@ ${GREEN}
 ####
 ${RESET}"
 read -n1 INSTALL
-if [[ ! $INSTALL =~ ^[Yy]$ ]]
+if [[ $INSTALL =~ ^[Yy]$ ]] ; then
     # Download current docker installs
+    printf "
+${GREEN}
+####
+# Downloading docker installers.
+###
+${RESET}"
     mkdir -p docker_installs
     for dockerurl in $DOCKER_URLS; do
         fname=$(basename $dockerurl)
-        if [ ! -f "docker_installs/$fname" ] ; then
-            if [[ $fname = *"dmg"* ]]; then
-                curl -sSL -o "docker_installs/Docker-$DOCKER_VERSION_MAC.dmg" $dockerurl
-            elif [[ $fname = *"exe"* ]]; then
-                curl -sSL -o "docker_installs/Docker-$DOCKER_VERSION_WIN.exe" $dockerurl
-            fi
+        if [[ $fname = *"dmg"* ]]; then
+            curl -sSL -o "docker_installs/Docker-$DOCKER_VERSION_MAC.dmg" $dockerurl
+        elif [[ $fname = *"exe"* ]] ; then
+            curl -sSL -o "docker_installs/Docker-$DOCKER_VERSION_WIN.exe" $dockerurl
         fi
     done
-then
-    exit 1
 fi
 
-cd $STAGING_DIR
 mkdir -p ddev_tarballs
 TARBALL="ddev_docker_images.$LATEST_VERSION.tar.xz"
 SHAFILE="$TARBALL.sha256.txt"

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -15,7 +15,7 @@ STAGING_DIR_NAME=drupal_sprint_package
 STAGING_DIR_BASE=~/tmp
 STAGING_DIR=$STAGING_DIR_BASE/$STAGING_DIR_NAME
 REPO_DIR=$PWD
-QUICKSPRINT_RELEASE=v0.0.6
+QUICKSPRINT_RELEASE=$(git describe --tags --always --dirty)
 
 # The version lines on the following few lines need to get changed any time the url are changed on the line below.
 DOCKER_URLS="https://download.docker.com/mac/stable/23751/Docker.dmg https://download.docker.com/win/stable/16762/Docker%20for%20Windows%20Installer.exe"
@@ -29,6 +29,9 @@ RESET='\033[0m'
 OS=$(uname)
 BINOWNER=$(ls -ld /usr/local/bin | awk '{print $3}')
 USER=$(whoami)
+
+# Ensure XZ is installed
+command -v xz >/dev/null 2>&1 || { echo >&2 "${RED}I require xz command but it's not installed. Aborting.${RESET}"; exit 1; }
 
 if [ -d "$STAGING_DIR" ] && [ ! -z "$(ls -A "$STAGING_DIR")" ] ; then
     printf "${RED}The staging directory already has files. Deleting them and recreating everything.${RESET}"
@@ -76,6 +79,8 @@ printf "
 ${GREEN}
 ####
 # Shall we package docker installers for mac and windows with the archive?
+#
+# Press y to include installers, or any other key to continue.
 # !!You don't need to hit enter!!.
 ####
 ${RESET}"
@@ -165,4 +170,4 @@ cd $STAGING_DIR_BASE
 tar -czf drupal_sprint_package$QUICKSPRINT_RELEASE.tar.gz $STAGING_DIR_NAME
 zip -9 -r -q drupal_sprint_package$QUICKSPRINT_RELEASE.zip $STAGING_DIR_NAME
 wait
-printf "${GREEN}The sprint tarballs and zipballs are in $(ls $STAGING_DIR_BASE/drupal_sprint_package*).${RESET}\n"
+printf "${GREEN}The sprint tarballs and zipballs are in $STAGING_DIR_BASE.${RESET}\n"

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -30,13 +30,8 @@ BINOWNER=$(ls -ld /usr/local/bin | awk '{print $3}')
 USER=$(whoami)
 
 if [ -d "$STAGING_DIR" ] && [ ! -z "$(ls -A "$STAGING_DIR")" ] ; then
-    echo -n "The staging directory already has files. Do you want to continue (y/n)? "
-    read answer
-    if echo "$answer" | grep -iq "^y"; then
-        echo "Continuing with downloads, existing files will be respected, mostly."
-    else
-        exit 1
-    fi
+    echo -n "The staging directory already has files. Deleting them and recreating everything."
+    rm -rf $STAGING_DIR
 fi
 
 SHACMD=""

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -170,4 +170,20 @@ cd $STAGING_DIR_BASE
 tar -czf drupal_sprint_package$QUICKSPRINT_RELEASE.tar.gz $STAGING_DIR_NAME
 zip -9 -r -q drupal_sprint_package$QUICKSPRINT_RELEASE.zip $STAGING_DIR_NAME
 wait
-printf "${GREEN}The sprint tarballs and zipballs are in $STAGING_DIR_BASE.${RESET}\n"
+
+printf "
+${GREEN}
+####
+# The built sprint tarballs and zipballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}.
+#
+# Now deleting the staging directory.
+####
+${RESET}"
+rm -rf $STAGING_DIR_NAME
+wait
+printf "
+${GREEN}
+####
+# Finished
+####
+${RESET}"

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -15,6 +15,7 @@ STAGING_DIR_NAME=drupal_sprint_package
 STAGING_DIR_BASE=~/tmp
 STAGING_DIR=$STAGING_DIR_BASE/$STAGING_DIR_NAME
 REPO_DIR=$PWD
+QUICKSPRINT_RELEASE=v0.0.6
 
 # The version lines on the following few lines need to get changed any time the url are changed on the line below.
 DOCKER_URLS="https://download.docker.com/mac/stable/23751/Docker.dmg https://download.docker.com/win/stable/16762/Docker%20for%20Windows%20Installer.exe"
@@ -152,7 +153,7 @@ if [ -f ${REPO_DIR}/package_additions.sh ]; then
 fi
 
 cd $STAGING_DIR_BASE
-tar -czf drupal_sprint_package.tar.gz $STAGING_DIR_NAME
-zip -9 -r -q drupal_sprint_package.zip $STAGING_DIR_NAME
+tar -czf drupal_sprint_package$QUICKSPRINT_RELEASE.tar.gz $STAGING_DIR_NAME
+zip -9 -r -q drupal_sprint_package$QUICKSPRINT_RELEASE.zip $STAGING_DIR_NAME
 wait
 printf "${GREEN}The sprint tarballs and zipballs are in $(ls $STAGING_DIR_BASE/drupal_sprint_package*).${RESET}\n"

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -102,6 +102,13 @@ ${RESET}"
             curl -sSL -o "docker_installs/Docker-$DOCKER_VERSION_WIN.exe" $dockerurl
         fi
     done
+else
+        printf "
+${GREEN}
+####
+# Continuing script without downloading Docker installers.
+###
+${RESET}"
 fi
 
 mkdir -p ddev_tarballs

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -16,7 +16,10 @@ STAGING_DIR_BASE=~/tmp
 STAGING_DIR=$STAGING_DIR_BASE/$STAGING_DIR_NAME
 REPO_DIR=$PWD
 
+# The version lines on the following few lines need to get changed any time the url are changed on the line below.
 DOCKER_URLS="https://download.docker.com/mac/stable/23751/Docker.dmg https://download.docker.com/win/stable/16762/Docker%20for%20Windows%20Installer.exe"
+DOCKER_VERSION_MAC="18.03.0-ce-mac60"
+DOCKER_VERSION_WIN="18.03.0-ce-win59"
 
 RED='\033[31m'
 GREEN='\033[32m'
@@ -65,6 +68,31 @@ if ! docker --version >/dev/null 2>&1; then
     printf "${YELLOW}Docker is required to use this package. Download and install docker at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
 fi
 
+printf "
+${GREEN}
+####
+# Shall we package docker installers for mac and windows with the archive?
+# !!You don't need to hit enter!!.
+####
+${RESET}"
+read -n1 INSTALL
+if [[ ! $INSTALL =~ ^[Yy]$ ]]
+    # Download current docker installs
+    mkdir -p docker_installs
+    for dockerurl in $DOCKER_URLS; do
+        fname=$(basename $dockerurl)
+        if [ ! -f "docker_installs/$fname" ] ; then
+            if [[ $fname = *"dmg"* ]]; then
+                curl -sSL -o "docker_installs/Docker-$DOCKER_VERSION_MAC.dmg" $dockerurl
+            elif [[ $fname = *"exe"* ]]; then
+                curl -sSL -o "docker_installs/Docker-$DOCKER_VERSION_WIN.exe" $dockerurl
+            fi
+        fi
+    done
+then
+    exit 1
+fi
+
 cd $STAGING_DIR
 mkdir -p ddev_tarballs
 TARBALL="ddev_docker_images.$LATEST_VERSION.tar.xz"
@@ -94,15 +122,6 @@ for os in macos linux windows; do
     pushd ddev_tarballs
     $SHACMD -c $(basename "$SHAFILE")
     popd
-done
-
-# Download current docker installs
-mkdir -p docker_installs
-for dockerurl in $DOCKER_URLS; do
-    fname=$(basename $dockerurl)
-    if [ ! -f "docker_installs/$fname" ] ; then
-        curl -sSL -o "docker_installs/$fname" $dockerurl
-    fi
 done
 
 # clone or refresh d8 clone

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -92,14 +92,11 @@ ${GREEN}
 #
 # Press y to include installers, or any other key to continue.
 # !!You don't need to hit enter!!.
-####
-${RESET}"
+####${RESET}"
 read -n1 INSTALL
 if [[ $INSTALL =~ ^[Yy]$ ]] ; then
     # Download current docker installs
-    printf "
-${GREEN}
-####
+    printf "${GREEN}
 # Downloading docker installers.
 ###
 ${RESET}"
@@ -113,10 +110,7 @@ ${RESET}"
         fi
     done
 else
-        printf "
-${GREEN}
-####
-# Continuing script without downloading Docker installers.
+    printf "${GREEN}# Continuing script without downloading Docker installers.
 ###
 ${RESET}"
 fi
@@ -153,17 +147,7 @@ done
 
 # clone or refresh d8 clone
 mkdir -p sprint
-if [ ! -d sprint.tar.xz ] ; then
-    git clone git://git.drupal.org/project/drupal.git $STAGING_DIR/sprint/drupal8
-else
-    pushd $STAGING_DIR
-    tar xpvf sprint.tar.xz -C sprint
-    rm sprint.tar.xz
-    cd $STAGING_DIR/sprint/drupal8
-    git pull
-    composer install
-    popd
-fi
+git clone git://git.drupal.org/project/drupal.git $STAGING_DIR/sprint/drupal8
 pushd $STAGING_DIR/sprint/drupal8
 cp $REPO_DIR/example.gitignore $STAGING_DIR/sprint/drupal8/.gitignore
 
@@ -188,19 +172,14 @@ tar -czf drupal_sprint_package$QUICKSPRINT_RELEASE.tar.gz $STAGING_DIR_NAME
 zip -9 -r -q drupal_sprint_package$QUICKSPRINT_RELEASE.zip $STAGING_DIR_NAME
 wait
 
-printf "
-${GREEN}
-####
+printf "${GREEN}####
 # The built sprint tarballs and zipballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}.
 #
 # Now deleting the staging directory.
-####
-${RESET}"
+####${RESET}"
 rm -rf $STAGING_DIR_NAME
 wait
-printf "
-${GREEN}
-####
+printf "${GREEN}
 # Finished
-####
-${RESET}"
+####${RESET}
+"

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -32,6 +32,16 @@ USER=$(whoami)
 
 # Ensure XZ is installed
 command -v xz >/dev/null 2>&1 || { echo >&2 "${RED}I require xz command but it's not installed. Aborting.${RESET}"; exit 1; }
+# Check Docker is running
+SERVICE='docker'
+if ps ax | grep -v grep | grep -v /Library/PrivilegedHelperTools/com.docker.vmnetd | grep $SERVICE > /dev/null
+then
+    printf "${GREEN}$SERVICE service running, continuing.\n${RESET}"
+else
+    printf "${RED}Docker is not running and is required for this script, exiting.\n${RESET}"
+    exit 1
+fi
+
 
 if [ -d "$STAGING_DIR" ] && [ ! -z "$(ls -A "$STAGING_DIR")" ] ; then
     printf "${RED}The staging directory already has files. Deleting them and recreating everything.${RESET}"

--- a/sprint/start_clean.cmd
+++ b/sprint/start_clean.cmd
@@ -30,7 +30,7 @@ ddev exec composer install
 ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db:3306/db
 ddev exec drush cr
 ddev describe
- 
+
 ECHO ####
 ECHO # run the following command:
 ECHO # 

--- a/sprint/start_clean.cmd
+++ b/sprint/start_clean.cmd
@@ -22,7 +22,8 @@ ECHO #
 ECHO ####
 PAUSE
 
-ddev start
+START /WAIT ddev remove >nul
+START /WAIT ddev start
 ddev exec git fetch
 ddev exec git reset --hard origin/8.6.x
 ddev exec composer install

--- a/sprint/start_clean.cmd
+++ b/sprint/start_clean.cmd
@@ -1,5 +1,14 @@
 @echo off
 
+REM check processs is running, via https://stackoverflow.com/a/1329790
+tasklist /FI "IMAGENAME eq Docker.exe" 2>NUL | find /I /N "Docker.exe">NUL
+if %ERRORLEVEL%==0
+    ECHO Docker is running, lets continue.
+) ELSE (
+    ECHO Docker isn't running and is required for this script, exiting.
+    EXIT
+)
+
 ECHO ####
 ECHO # This simple script starts a clean instance of drupal 
 ECHO # running in ddev and imports a starter database.

--- a/sprint/start_clean.cmd
+++ b/sprint/start_clean.cmd
@@ -5,12 +5,13 @@ ECHO # This simple script starts a clean instance of drupal
 ECHO # running in ddev and imports a starter database.
 ECHO #
 ECHO # Make sure you've uploaded any patches from last issue 
-ECHO # you worked on before continuing.
+ECHO # you worked on before continuing, as this blow away
+ECHO # local changes.
 ECHO #
-ECHO # Press y to continue
-ECHO # !!You don't need to hit enter!!.
+ECHO # Press any key to continue
 ECHO #
 ECHO ####
+PAUSE
 
 ddev start
 ddev exec git fetch

--- a/sprint/start_clean.cmd
+++ b/sprint/start_clean.cmd
@@ -10,8 +10,8 @@ if %ERRORLEVEL%==0
 )
 
 ECHO ####
-ECHO # This simple script starts a clean instance of drupal 
-ECHO # running in ddev and imports a starter database.
+ECHO # This simple script starts a Drupal 8 checked out from head
+ECHO # running in ddev with a fresh database.
 ECHO #
 ECHO # Make sure you've uploaded any patches from last issue 
 ECHO # you worked on before continuing, as this blow away

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -34,8 +34,7 @@ then
     exit 1
 fi
 
-printf "
-"
+printf "\n"
 ddev remove
 ddev start
 wait

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -45,7 +45,8 @@ then
 fi
 
 printf "\n"
-ddev remove
+ddev remove >/dev/null 2>&1
+wait
 ddev start
 wait
 ddev exec git fetch

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -12,6 +12,16 @@ GREEN='\033[32m'
 YELLOW='\033[33m'
 RESET='\033[0m'
 
+# Check Docker is running
+SERVICE='docker'
+if ps ax | grep -v grep | grep -v /Library/PrivilegedHelperTools/com.docker.vmnetd | grep $SERVICE > /dev/null
+then
+    printf "${GREEN}$SERVICE service running, continuing.\n${RESET}"
+else
+    printf "${RED}Docker is not running and is required for this script, exiting.\n${RESET}"
+    exit 1
+fi
+
 printf "
 ${GREEN}
 ####

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -15,11 +15,12 @@ RESET='\033[0m'
 printf "
 ${GREEN}
 ####
-# This simple script starts a clean instance of drupal
+# This simple script starts a clean Drupal 8 instance
 # running in ddev and imports a starter database.
 #
 # Make sure you've uploaded any patches from last issue
-# you worked on before continuing.
+# you worked on before continuing, as this blow away
+# local changes.
 #
 # Press y to continue, or any other key to exit the script.
 # !!You don't need to hit enter!!.

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -15,13 +15,13 @@ RESET='\033[0m'
 printf "
 ${GREEN}
 ####
-# This simple script starts a clean instance of drupal 
+# This simple script starts a clean instance of drupal
 # running in ddev and imports a starter database.
 #
-# Make sure you've uploaded any patches from last issue 
+# Make sure you've uploaded any patches from last issue
 # you worked on before continuing.
 #
-# Press y to continue
+# Press y to continue, or any other key to exit the script.
 # !!You don't need to hit enter!!.
 #
 ####
@@ -29,6 +29,7 @@ ${RESET}"
 read -n1 INSTALL
 if [[ ! $INSTALL =~ ^[Yy]$ ]]
 then
+    printf "${RED}You didn't hit y or Y, exiting script${RESET}"
     exit 1
 fi
 

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -54,6 +54,7 @@ ddev exec git reset --hard origin/8.6.x
 ddev exec composer install
 ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db:3306/db
 ddev exec drush cr
+ddev describe
 
 printf "
 ${GREEN}

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o errexit
+set -o pipefail
+set -o nounset
+
 #Clear terminal screen so the about text can be read
 clear
 

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -25,8 +25,8 @@ fi
 printf "
 ${GREEN}
 ####
-# This simple script starts a clean Drupal 8 instance
-# running in ddev and imports a starter database.
+# This simple script starts a Drupal 8 checked out from head
+# running in ddev with a fresh database.
 #
 # Make sure you've uploaded any patches from last issue
 # you worked on before continuing, as this blow away

--- a/start_sprint.cmd
+++ b/start_sprint.cmd
@@ -1,4 +1,9 @@
 @echo off
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
 CLS
 
 goto check_Permissions

--- a/start_sprint.cmd
+++ b/start_sprint.cmd
@@ -35,7 +35,7 @@ set SANEHOUR=%HOUR: =0%
 set TIMESTAMP=%date:~10,4%%date:~7,2%%date:~4,2%-%SANEHOUR%%time:~3,2%
 
 REM #Extract a new ddev D8 core instance to $CWD/sprint-$TIMESTAMP
-bin\7za.exe x sprint.tar.xz -so | bin\7za.exe x -aoa -si -ttar -osprint-%TIMESTAMP%
+bin\7za.exe x sprint.tar.xz -so > nul | bin\7za.exe x -aoa -si -ttar -osprint-%TIMESTAMP% > nul
 
 REM #Update ddevproject name
 bin\sed.exe -i s/\[ts\]/%TIMESTAMP%/ sprint-%TIMESTAMP%/.ddev/config.yaml

--- a/start_sprint.cmd
+++ b/start_sprint.cmd
@@ -50,6 +50,6 @@ ECHO # execute the following commands in terminal
 ECHO # to start a Drupal 8 instance to sprint on:
 ECHO #
 ECHO # cd sprint-%TIMESTAMP%
-ECHO # start_clean.cmd
+ECHO # start_clean.cmd (don't run this as administrator)
 ECHO #
 ECHO ######

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -13,7 +13,7 @@ TIMESTAMP=$(date +"%Y%m%d-%H%M")
 
 #Extract a new ddev D8 core instance to $CWD/sprint-$TIMESTAMP
 mkdir -p sprint-$TIMESTAMP
-tar xpvf sprint.tar.xz -C sprint-$TIMESTAMP
+tar xpf sprint.tar.xz -C sprint-$TIMESTAMP
 wait
 
 #Update ddev project name


### PR DESCRIPTION
[#21] Ensure ddev is added to path, Let the user know we exited if they didn’t hit Y/y, add that install should be run via terminal on mac and Linux.
[#26] Added error checking to all shell scripts.
[#28] add release version to archive filename.
[#30] Don’t install docker by default, improve messaging about Docker memory requirement.
[#31] Add version number to Docker installers, remove spaces from filenames, make packaging of installers optional. Don’t automatically install docker on mac, make the user do it manually instead. Improve visibility of requirement to increase docker memory limit.
[#30 #31] When running packaging script, delete and build it clean if staging dir already exists.