### PR TITLE
Fix gzip option -9e doesn't work

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -6,7 +6,7 @@ set -o nounset
 
 # Maximise compression
 export XZ_OPT=-9e
-export GZIP=-9e
+export GZIP=-9
 
 # This script creates a package of artifacts that can then be used at a code sprint working on Drupal 8.
 # It assumes it's being run in the repository root.


### PR DESCRIPTION
As noted elsewhere in an unrelated PR, the GZIP option -9e isn't valid, remove that.