### PR TITLE
Runs ddev config before ddev start and updates config.yaml (#66)

### DIFF
--- a/sprint/.ddev/config.yaml
+++ b/sprint/.ddev/config.yaml
@@ -5,7 +5,7 @@ docroot: drupal8
 php_version: "7.2"
 router_http_port: "8080"
 router_https_port: "8443"
-xdebug_enabled: true
+xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
 provider: default

--- a/sprint/.ddev/config.yaml
+++ b/sprint/.ddev/config.yaml
@@ -1,17 +1,67 @@
-APIVersion: "1"
+APIVersion: v1.0.0
 name: sprint-[ts]
 type: drupal8
 docroot: drupal8
 php_version: "7.2"
 router_http_port: "8080"
 router_https_port: "8443"
+xdebug_enabled: true
+additional_hostnames: []
+additional_fqdns: []
 provider: default
 
-# Certain ddev commands can be extended to run tasks before or after the ddev
-# command is executed.
+# This config.yaml was created with ddev version v1.0.0
+# webimage: drud/ddev-webserver:v1.0.0
+# dbimage: drud/ddev-dbserver:v1.0.0
+# dbaimage: drud/phpmyadmin:v1.0.0
+# However we do not recommend explicitly wiring these images into the
+# config.yaml as they may break future versions of ddev.
+# You can update this config.yaml using 'ddev config'.
+
+# Key features of ddev's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides
+#   http://projectname.ddev.local and https://projectname.ddev.local
+
+# type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "7.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2"
+
+# You can explicitly specify the webimage, dbimage, dbaimage lines but this
+# is not recommended, as the images are often closely tied to ddev's' behavior,
+# so this can break upgrades.
+
+# webimage: <docker_image>  # nginx/php docker image.
+# dbimage: <docker_image>  # mariadb docker image.
+# dbaimage: <docker_image>
+
+# router_http_port: <port>  # Port to be used for http (defaults to port 80)
+# router_https_port: <port> # Port for https (defaults to 443)
+
+# xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
+
+#additional_hostnames:
+# - somename
+# - someothername
+# would provide http and https URLs for "somename.ddev.local"
+# and "someothername.ddev.local".
+
+#additional_fqdns:
+# - example.com
+# - sub1.example.com
+# would provide http and https URLs for "example.com" and "sub1.example.com"
+# Please take care with this because it can cause great confusion.
+
+# provider: default # Currently either "default" or "pantheon"
+#
+# Many ddev commands can be extended to run tasks after the ddev command is
+# executed.
 # See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more
 # information on the commands that can be extended and the tasks you can define
-# for them.
-# hooks:
-#   post-import-db:
-#     - exec: "drush cr"
+# for them. Example:
+#hooks:
+# post-import-db:
+#   - exec: drush cr
+#   - exec: drush updb

--- a/sprint/start_clean.cmd
+++ b/sprint/start_clean.cmd
@@ -23,7 +23,7 @@ ECHO ####
 PAUSE
 
 REM Attempts to reconfigure ddev to update config automagically.
-ddev config default --docroot drupal8 --projecttype drupal8 --projectname sprint-[ts]
+ddev config --docroot drupal8 --projecttype drupal8 --projectname sprint-[ts]
 
 ddev start
 ddev exec git fetch

--- a/sprint/start_clean.cmd
+++ b/sprint/start_clean.cmd
@@ -22,6 +22,9 @@ ECHO #
 ECHO ####
 PAUSE
 
+REM Attempts to reconfigure ddev to update config automagically.
+ddev config default --docroot drupal8 --projecttype drupal8 --projectname sprint-[ts]
+
 ddev start
 ddev exec git fetch
 ddev exec git reset --hard origin/8.6.x

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -43,6 +43,10 @@ while true; do
     esac
 done
 
+
+# Attempts to reconfigure ddev to update config automagically.
+ddev config default --docroot drupal8 --projectname sprint-[ts] --projecttype drupal8
+
 ddev start
 ddev exec git fetch
 ddev exec git reset --hard origin/8.6.x

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -45,7 +45,7 @@ done
 
 
 # Attempts to reconfigure ddev to update config automagically.
-ddev config default --docroot drupal8 --projectname sprint-[ts] --projecttype drupal8
+ddev config --docroot drupal8 --projectname sprint-[ts] --projecttype drupal8
 
 ddev start
 ddev exec git fetch

--- a/start_sprint.cmd
+++ b/start_sprint.cmd
@@ -22,13 +22,13 @@ set MONTH=%MONTH:~-2%
 set TIMESTAMP=%YEAR%%MONTH%%DAY%-%HOUR%%MINUTE%
 
 REM #Extract a new ddev D8 core instance to $CWD/sprint-$TIMESTAMP
-bin\7za.exe x sprint.tar.xz -so | bin\7za.exe x -aoa -si -ttar -osprint-%TIMESTAMP% 2> nul
+bin\windows\7za.exe x sprint.tar.xz -so | bin\windows\7za.exe x -aoa -si -ttar -osprint-%TIMESTAMP% 2> nul
 
 REM #Update ddevproject name
-bin\sed.exe -i s/\[ts\]/%TIMESTAMP%/ sprint-%TIMESTAMP%/.ddev/config.yaml
-bin\sed.exe -i s/\[ts\]/%TIMESTAMP%/ sprint-%TIMESTAMP%/Readme.txt
-bin\sed.exe -i s/\[ts\]/%TIMESTAMP%/ sprint-%TIMESTAMP%/start_clean.sh
-bin\sed.exe -i s/\[ts\]/%TIMESTAMP%/ sprint-%TIMESTAMP%/start_clean.cmd
+bin\windows\sed.exe -i s/\[ts\]/%TIMESTAMP%/ sprint-%TIMESTAMP%/.ddev/config.yaml
+bin\windows\sed.exe -i s/\[ts\]/%TIMESTAMP%/ sprint-%TIMESTAMP%/Readme.txt
+bin\windows\sed.exe -i s/\[ts\]/%TIMESTAMP%/ sprint-%TIMESTAMP%/start_clean.sh
+bin\windows\sed.exe -i s/\[ts\]/%TIMESTAMP%/ sprint-%TIMESTAMP%/start_clean.cmd
 
 ECHO ######
 ECHO #

--- a/test_drupal_quicksprint.sh
+++ b/test_drupal_quicksprint.sh
@@ -25,12 +25,12 @@ echo y | ./start_sprint.sh
 cd ~/Sites/sprint/sprint-2* && echo y | ./start_clean.sh
 
 # Confirms web and router status.
-ddev describe | grep -q running || exit 1
-ddev describe | grep -q "DDEV ROUTER STATUS: healthy" || exit 1
+ddev describe | grep running || { echo "ERROR: ddev web is not running correctly?"; exit 1; }
+ddev describe | grep "DDEV ROUTER STATUS: healthy" || { echo "ERROR: ddev router status is not healthy?" ; exit 1; }
 
 # Confirms site is responding with 200.
 SITE_URL=`ddev describe | grep -o -m 1 "https://sprint-[0-9\-]\+\.ddev\.local"`
-curl -k -L -I --silent ${SITE_URL}:8443 | head -n 1 | grep -q 200 || echo "ERROR: Could not connect to ${SITE_URL}:8443!"; exit 1
+curl -k -L -I ${SITE_URL}:8443 | head -n 1 | grep -q 200 || { echo "ERROR: Could not connect to ${SITE_URL}:8443!"; exit 1; }
 
 rm -r /tmp/drupal_sprint_package
 

--- a/test_drupal_quicksprint.sh
+++ b/test_drupal_quicksprint.sh
@@ -15,8 +15,11 @@ tar -C /tmp -zxf ~/tmp/drupal_sprint_package.no_docker.$(cat ./.quicksprint_rele
 # Run the standard install_ddev.sh, asserting we already have docker set up.
 cd /tmp/drupal_sprint_package && echo y | ./install_ddev.sh
 
+
 # Remove any existing sprints, then do start_sprint.sh
-cd ~/Sites/sprint && chmod -R u+w sprint-* && rm -rf sprint-* echo y | ./start_sprint.sh
+cd ~/Sites/sprint
+find ~/Sites/sprint -type d -name "sprint-2*" -exec chmod -R u+w '{}' \; -exec rm -rf '{}' \;
+echo y | ./start_sprint.sh
 
 # Run start_sprint in the (only) sprint directory
 cd ~/Sites/sprint/sprint-2* && echo y | ./start_clean.sh

--- a/test_drupal_quicksprint.sh
+++ b/test_drupal_quicksprint.sh
@@ -24,6 +24,14 @@ echo y | ./start_sprint.sh
 # Run start_sprint in the (only) sprint directory
 cd ~/Sites/sprint/sprint-2* && echo y | ./start_clean.sh
 
+# Confirms web and router status.
+ddev describe | grep -q running || exit 1
+ddev describe | grep -q "DDEV ROUTER STATUS: healthy" || exit 1
+
+# Confirms site is responding with 200.
+SITE_URL=`ddev describe | grep -o -m 1 "https://sprint-[0-9\-]\+\.ddev\.local"`
+curl -k -L -I --silent ${SITE_URL}:8443 | head -n 1 | grep -q 200 || echo "ERROR: Could not connect to ${SITE_URL}:8443!"; exit 1
+
 rm -r /tmp/drupal_sprint_package
 
 echo "Test successful"

--- a/test_drupal_quicksprint.sh
+++ b/test_drupal_quicksprint.sh
@@ -4,9 +4,9 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-TEST_FAIL_ROUTER=9000
-TEST_FAIL_WEB=9001
-TEST_FAIL_DRUPAL=9002
+TEST_FAIL_ROUTER=50
+TEST_FAIL_WEB=51
+TEST_FAIL_DRUPAL=52
 
 # Initial setup: Make sure we have no ddev
 if which ddev; then


### PR DESCRIPTION
This addresses #66.

Tested shell script version on MacOS Sierra (works) and Linux (nginx didn't start without explicitly running as root):

- Without an explicit sudo (the shell script runs a sudo command), on MacOS, it is still treated as running as root since I still get the "Warning: containers will run as root. This could be a security risk on Linux", but I do not get that message on Slackware and the web container times out because nginx fails to start.
- With an explicit sudo, nginx does start, and docker does output the root warning above.

Todo:

- [x] Test on MacOS
- [x] Test on Linux (do a test on a more heavily used distro than the one I use)
- [x] Test on a Windows 10 desktop I have access to