### PR TITLE
Improve tests, bats tests should not include setup (or state)

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -10,4 +10,4 @@ echo "n" | ./package_drupal_script.sh
 echo "--- test_drupal_quicksprint.sh"
 tests/test_drupal_quicksprint.sh
 echo "--- cleanup"
-rm "~/tmp/drupal_sprint_package.no_docker.$(cat .quicksprint_release.txt).tar.gz"
+rm -f ~/tmp/drupal_sprint_package.no_docker.$(cat .quicksprint_release.txt).tar.gz

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -8,4 +8,4 @@ echo "--- buildkite building at $(date) on $(hostname) for OS=$(go env GOOS) in 
 echo "--- package_drupal_script.sh"
 echo "n" | ./package_drupal_script.sh
 echo "--- test_drupal_quicksprint.sh"
-./test_drupal_quicksprint.sh
+tests/test_drupal_quicksprint.sh

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -9,3 +9,5 @@ echo "--- package_drupal_script.sh"
 echo "n" | ./package_drupal_script.sh
 echo "--- test_drupal_quicksprint.sh"
 tests/test_drupal_quicksprint.sh
+echo "--- cleanup"
+rm "~/tmp/drupal_sprint_package.no_docker.$(cat .quicksprint_release.txt).tar.gz"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           no_output_timeout: "20m"
       - run:
           command: |
-            sudo mkdir $ARTIFACTS && sudo chmod ugo+w $ARTIFACTS && cp ~/tmp/drupal_sprint_package* $ARTIFACTS
+            sudo mkdir $ARTIFACTS && sudo chmod ugo+w $ARTIFACTS && cp ~/tmp/drupal_sprint_package.$(cat .quicksprint_release.txt).{tar.gz,zip}  $ARTIFACTS
             cd $ARTIFACTS
             for item in *.tar.gz *.zip; do
               sha256sum $item > $item.sha256.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - store_artifacts:
           path: /artifacts
           name: Artifact storage
-      - run: ./test_drupal_quicksprint.sh
+      - run: tests/test_drupal_quicksprint.sh
 
 workflows:
   version: 2

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -14,6 +14,7 @@ USER=$(whoami)
 SHACMD=""
 FILEBASE=""
 CURRENT_DIR=$PWD
+DDEV_VERSION=$(cat ./.ddev_version.txt)
 
 # Check Docker is running
 if docker run --rm -t busybox:latest ls >/dev/null
@@ -46,9 +47,9 @@ echo "Installing docker images for ddev to use..."
 if [ $OS = "MINGW64_NT-10.0" ] ; then PATH="./bin/windows:$PATH"; fi
 
 
-if command -v 7z; then
-    7z x ddev_tarballs/ddev_docker_images.*.tar.xz -so | docker load
-elif command -v xzcat; then
+if command -v 7z >/dev/null; then
+    7z x ddev_tarballs/ddev_docker_images.${DDEV_VERSION}.tar.xz -so | docker load
+elif command -v xzcat >/dev/null; then
     xzcat ddev_tarballs/ddev_docker_images*.tar.xz | docker load
 elif [[ "$OS" == "Darwin" ]]; then
     gzip -dc ls ddev_tarballs/ddev_docker_images*.tar.xz | docker load

--- a/install_ddev.sh
+++ b/install_ddev.sh
@@ -19,7 +19,7 @@ DDEV_VERSION=$(cat ./.ddev_version.txt)
 # Check Docker is running
 if docker run --rm -t busybox:latest ls >/dev/null
 then
-    printf "docker service running, continuing."
+    printf "docker is running, continuing."
 else
     printf "${RED}Docker is not running and is required for this script, exiting.\n${RESET}"
     exit 1

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -149,7 +149,7 @@ cd ${STAGING_DIR}
 
 echo "Creating tar and zipballs"
 # Create tar.xz archive without using xz command, so we can work on all platforms
-pushd sprint >/dev/null && 7z a -ttar -so bogusfilename.tar . | 7z a -si -txz ../sprint.tar.xz >/dev/null && popd >/dev/null
+pushd sprint >/dev/null && 7z a -ttar -so bogusfilename.tar . 2>/dev/null | 7z a -si -txz ../sprint.tar.xz >/dev/null && popd >/dev/null
 rm -rf ${STAGING_DIR}/sprint
 
 cd ${STAGING_DIR_BASE}

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -48,12 +48,7 @@ fi
 if [ -d "$STAGING_DIR" ] && [ ! -z "$(ls -A "$STAGING_DIR")" ] ; then
     printf "${RED}The staging directory $STAGING_DIR already has files. Deleting them and recreating everything.${RESET}"
     rm -rf "$STAGING_DIR"
-    if [ -e "$STAGING_DIR_BASE/drupal_sprint_package$QUICKSPRINT_RELEASE.tar.gz" ] ; then
-        rm "$STAGING_DIR_BASE/drupal_sprint_package$QUICKSPRINT_RELEASE.tar.gz"
-    fi
-    if [ -e "$STAGING_DIR_BASE/drupal_sprint_package$QUICKSPRINT_RELEASE.zip" ]; then
-        rm "$STAGING_DIR_BASE/drupal_sprint_package$QUICKSPRINT_RELEASE.zip"
-    fi
+    rm -f $STAGING_DIR_BASE/drupal_sprint_package${QUICKSPRINT_RELEASE}.*
 fi
 
 SHACMD="sha256sum"
@@ -158,8 +153,10 @@ pushd sprint >/dev/null && 7z a -ttar -so bogusfilename.tar . | 7z a -si -txz ..
 rm -rf ${STAGING_DIR}/sprint
 
 cd ${STAGING_DIR_BASE}
-tar -czf drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz ${STAGING_DIR_NAME}
-zip -9 -r -q drupal_sprint_package.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
+if [ "$INSTALL" != "n" ] ; then
+    tar -czf drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz ${STAGING_DIR_NAME}
+    zip -9 -r -q drupal_sprint_package.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
+fi
 rm -rf ${STAGING_DIR_NAME}/installs
 tar -czf drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz ${STAGING_DIR_NAME}
 zip -9 -r -q drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
@@ -169,7 +166,8 @@ printf "${GREEN}####
 #
 # Now deleting the staging directory.
 ####${RESET}"
-rm -rf ${STAGING_DIR_NAME}
+# DEBUG: Don't forget to turn this back on.
+# rm -rf ${STAGING_DIR_NAME}
 
 printf "${GREEN}
 # Finished

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -48,7 +48,7 @@ fi
 if [ -d "$STAGING_DIR" ] && [ ! -z "$(ls -A "$STAGING_DIR")" ] ; then
     printf "${RED}The staging directory $STAGING_DIR already has files. Deleting them and recreating everything.${RESET}"
     rm -rf "$STAGING_DIR"
-    rm -f $STAGING_DIR_BASE/drupal_sprint_package${QUICKSPRINT_RELEASE}.*
+    rm -f $STAGING_DIR_BASE/drupal_sprint_package.*.${QUICKSPRINT_RELEASE}.*
 fi
 
 SHACMD="sha256sum"

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -61,7 +61,7 @@ echo "$LATEST_VERSION" >.ddev_version.txt
 
 # Install the beginning items we need in the kit.
 mkdir -p ${STAGING_DIR}
-cp -r .ddev_version.txt .quicksprint_release.txt bin sprint start_sprint.* SPRINTUSER_README.md install_ddev.* ${STAGING_DIR}
+cp -r .ddev_version.txt .quicksprint_release.txt bin sprint start_sprint.* SPRINTUSER_README.md install_ddev.sh ${STAGING_DIR}
 
 
 # macOS/Darwin has a oneoff/weird shasum command.
@@ -70,7 +70,7 @@ if [ "$OS" = "Darwin" ]; then
 fi
 
 if ! docker --version >/dev/null 2>&1; then
-    printf "${YELLOW}Docker is required to use this package. Download and install docker at https://www.docker.com/community-edition#/download before attempting to use ddev.${RESET}\n"
+    printf "${YELLOW}Docker is required to use this package. Please install docker before attempting to use ddev.${RESET}\n"
 fi
 
 cd ${STAGING_DIR}
@@ -78,7 +78,7 @@ cd ${STAGING_DIR}
 printf "
 ${GREEN}
 ####
-# Shall we package docker and other installers (Git For Windows, etc) with the archive?
+# Package docker and other installers (Git For Windows, etc)?
 #### \n${RESET}"
 
 while true; do
@@ -113,7 +113,7 @@ ${SHACMD} -c "$SHAFILE"
 popd >/dev/null
 
 # Download the ddev tarball/zipball
-for item in macos linux windows_installer; do
+for item in macos linux windows windows_installer; do
     pwd
     SUFFIX=tar.gz
     if [ ${item} == "windows_installer" ] ; then

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -144,11 +144,11 @@ cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 
 echo "Running composer install --quiet"
 composer install --quiet
+popd >/dev/null
 
 # Copy licenses and COPYING notice.
-cp -r ${REPO_DIR}/licenses "$STAGING_DIR/"
-cp ${REPO_DIR}/COPYING "$STAGING_DIR/"
-popd >/dev/null
+cp -r ${REPO_DIR}/licenses ${REPO_DIR}/COPYING "$STAGING_DIR/"
+cp ${REPO_DIR}/.quicksprint_release.txt $REPO_DIR/.ddev_version.txt "$STAGING_DIR/sprint"
 
 cd ${STAGING_DIR}
 

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -166,8 +166,7 @@ printf "${GREEN}####
 #
 # Now deleting the staging directory.
 ####${RESET}"
-# DEBUG: Don't forget to turn this back on.
-# rm -rf ${STAGING_DIR_NAME}
+rm -rf ${STAGING_DIR_NAME}
 
 printf "${GREEN}
 # Finished

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -12,7 +12,7 @@ RESET='\033[0m'
 # Check Docker is running
 if docker run --rm -t busybox:latest ls >/dev/null
 then
-    printf "docker service running, continuing."
+    printf "docker is running, continuing."
 else
     printf "${RED}Docker is not running and is required for this script, exiting.\n${RESET}"
     exit 1
@@ -44,7 +44,8 @@ done
 ddev config --docroot drupal8 --projectname sprint-[ts] --projecttype drupal8
 
 ddev start
-time ddev exec bash -c 'git fetch && git reset --hard origin/8.7.x && composer install && drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting" && drush cr'
+ddev exec bash -c 'git fetch && git reset --hard origin/8.7.x && composer install && drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting" && drush cr'
+printf "${RESET}"
 ddev describe
 
 printf "

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -21,7 +21,7 @@ fi
 printf "
 ${GREEN}
 ####
-# This simple script starts a Drupal 8 checked out from head
+# This script starts a Drupal 8 instance checked out from head
 # running in ddev with a fresh database.
 #
 # Make sure you've uploaded any patches from last issue
@@ -44,11 +44,7 @@ done
 ddev config --docroot drupal8 --projectname sprint-[ts] --projecttype drupal8
 
 ddev start
-ddev exec git fetch
-ddev exec git reset --hard origin/8.7.x
-ddev exec composer install
-ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db:3306/db --site-name="Drupal Sprinting"
-ddev exec drush cr
+time ddev exec bash -c 'git fetch && git reset --hard origin/8.7.x && composer install && drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting" && drush cr'
 ddev describe
 
 printf "

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -43,6 +43,7 @@ done
 # Attempts to reconfigure ddev to update config automagically.
 ddev config --docroot drupal8 --projectname sprint-[ts] --projecttype drupal8
 
+echo "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}"
 ddev start
 ddev exec bash -c 'git fetch && git reset --hard origin/8.7.x && composer install && drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting" && drush cr'
 printf "${RESET}"

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -12,15 +12,17 @@ YELLOW='\033[33m'
 RESET='\033[0m'
 OS=$(uname)
 TIMESTAMP=$(date +"%Y%m%d-%H%M")
+SPRINTNAME="sprint-${TIMESTAMP}"
 
 # Extract a new ddev D8 core instance to $CWD/sprint-$TIMESTAMP
-mkdir -p sprint-${TIMESTAMP}
+mkdir -p ${SPRINTNAME}
 echo "Untarring sprint.tar.xz"
-tar xpf sprint.tar.xz -C sprint-${TIMESTAMP}
+tar xpf sprint.tar.xz -C ${SPRINTNAME}
 
 #Update ddev project name
-perl -pi -e "s/\[ts\]/${TIMESTAMP}/g" sprint-${TIMESTAMP}/*.{txt,sh} sprint-${TIMESTAMP}/.ddev/config.yaml
+perl -pi -e "s/\[ts\]/${TIMESTAMP}/g" ${SPRINTNAME}/*.{txt,sh} ${SPRINTNAME}/.ddev/config.yaml
 
+printf ${SPRINTNAME}
 printf "${GREEN}
 ######
 #
@@ -28,9 +30,9 @@ printf "${GREEN}
 # execute the following commands in terminal 
 # to start a Drupal 8 instance to sprint on:
 #
-# ${YELLOW}cd sprint-${TIMESTAMP}${GREEN}
+# ${YELLOW}cd ${SPRINTNAME}${GREEN}
 # ${YELLOW}./start_clean.sh${GREEN}
 #
 ######
 ${RESET}
-"
+" >&2

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -16,13 +16,16 @@ SPRINTNAME="sprint-${TIMESTAMP}"
 
 # Extract a new ddev D8 core instance to $CWD/sprint-$TIMESTAMP
 mkdir -p ${SPRINTNAME}
-echo "Untarring sprint.tar.xz"
+echo "Untarring sprint.tar.xz" >&2
 tar xpf sprint.tar.xz -C ${SPRINTNAME}
 
 #Update ddev project name
 perl -pi -e "s/\[ts\]/${TIMESTAMP}/g" ${SPRINTNAME}/*.{txt,sh} ${SPRINTNAME}/.ddev/config.yaml
 
+# Next line is (only) stdout output, lets caller know the name of the project created
 printf ${SPRINTNAME}
+
+# And this goes to stderr
 printf "${GREEN}
 ######
 #

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -17,7 +17,7 @@ SPRINTNAME="sprint-${TIMESTAMP}"
 # Extract a new ddev D8 core instance to $CWD/sprint-$TIMESTAMP
 mkdir -p ${SPRINTNAME}
 echo "Untarring sprint.tar.xz" >&2
-tar xpf sprint.tar.xz -C ${SPRINTNAME}
+tar -xpf sprint.tar.xz -C ${SPRINTNAME}
 
 #Update ddev project name
 perl -pi -e "s/\[ts\]/${TIMESTAMP}/g" ${SPRINTNAME}/*.{txt,sh} ${SPRINTNAME}/.ddev/config.yaml

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -16,17 +16,21 @@ function setup {
     cd ${SPRINTDIR}/${SPRINT_NAME} && echo y | ./start_clean.sh
 }
 
+function teardown {
+    ddev rm -R ${SPRINT_NAME}
+    rm -rf ${SPRINTDIR}/${SPRINT_NAME}
+}
 
-@test "check ddev project status and router status" {
+@test "check ddev project status and router status, check http status" {
+
+    [ -f ${SPRINTDIR}/SPRINTUSER_README.md -a -f ${SPRINTDIR}/COPYING -a -d ${SPRINTDIR}/licenses ]
     DESCRIBE=$(cd ${SPRINTDIR}/${SPRINT_NAME} && ddev describe -j)
     ROUTER_STATUS=$(echo $DESCRIBE | jq -r ".raw.router_status" )
     [ "$ROUTER_STATUS" = "healthy" ]
 
     STATUS=$(echo $DESCRIBE | jq -r ".raw.status")
     [ "$STATUS" = "running" ]
-}
 
-@test "check http status of project for 200" {
     DESCRIBE=$(cd ${SPRINTDIR}/${SPRINT_NAME} && ddev describe -j)
     NAME=$(echo $DESCRIBE | jq -r ".raw.name")
     HTTP_PORT=$(echo $DESCRIBE | jq -r ".raw.router_http_port")
@@ -35,6 +39,7 @@ function setup {
     echo "# curl: $CURL" >&3
     $CURL
 }
+
 
 # todo:
 # Test that drush works inside container

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -17,29 +17,27 @@ function setup {
 }
 
 function teardown {
-    ddev rm -R ${SPRINT_NAME}
-    rm -rf ${SPRINTDIR}/${SPRINT_NAME}
+    ddev rm -R --omit-snapshot ${SPRINT_NAME}
+    if [ ! -z "${SPRINTDIR}" -a ! -z "${SPRINT_NAME}" -a -d ${SPRINTDIR}/${SPRINT_NAME} ] ; then
+        rm -rf ${SPRINTDIR}/${SPRINT_NAME};
+    fi
 }
 
 @test "check ddev project status and router status, check http status" {
 
     [ -f ${SPRINTDIR}/SPRINTUSER_README.md -a -f ${SPRINTDIR}/COPYING -a -d ${SPRINTDIR}/licenses ]
     DESCRIBE=$(cd ${SPRINTDIR}/${SPRINT_NAME} && ddev describe -j)
-    ROUTER_STATUS=$(echo $DESCRIBE | jq -r ".raw.router_status" )
+    ROUTER_STATUS=$(echo ${DESCRIBE} | jq -r ".raw.router_status" )
     [ "$ROUTER_STATUS" = "healthy" ]
 
-    STATUS=$(echo $DESCRIBE | jq -r ".raw.status")
+    STATUS=$(echo ${DESCRIBE} | jq -r ".raw.status")
     [ "$STATUS" = "running" ]
 
     DESCRIBE=$(cd ${SPRINTDIR}/${SPRINT_NAME} && ddev describe -j)
-    NAME=$(echo $DESCRIBE | jq -r ".raw.name")
-    HTTP_PORT=$(echo $DESCRIBE | jq -r ".raw.router_http_port")
+    NAME=$(echo ${DESCRIBE} | jq -r ".raw.name")
+    HTTP_PORT=$(echo ${DESCRIBE} | jq -r ".raw.router_http_port")
     URL="http://${DHOST}:${HTTP_PORT}"
     CURL="curl --fail -H 'Host: ${NAME}.ddev.local' --silent --output /dev/null --url $URL"
     echo "# curl: $CURL" >&3
-    $CURL
+    ${CURL}
 }
-
-
-# todo:
-# Test that drush works inside container

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -4,8 +4,6 @@
 # bats tests
 
 function setup {
-    export UNTAR_LOCATION=/tmp
-    export SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_docker.$(cat .quicksprint_release.txt).tar.gz
     export SPRINTDIR=~/sprint
     # DRUD_NONINTERACTIVE causes ddev not to try to use sudo and add the hostname
     export DRUD_NONINTERACTIVE=true
@@ -13,35 +11,11 @@ function setup {
     DHOST=127.0.0.1
     # Extract the IP address we need from DOCKER_HOST, which is formatted like tcp://192.168.99.100:2376
     if [ ! -z "$DOCKER_HOST" ]; then DHOST="$(echo $DOCKER_HOST | perl -p -e 's/(tcp:\/\/|:[0-9]+$)//g')"; fi
-}
 
-# brew install jq p7zip bats-core composer
-# choco install -y jq 7zip composer zip (gd and curl must be enabled in /c/tools/php72/php.ini)
-# apt-get install jq p7zip-full
-# git clone git://github.com/bats-core/bats-core; cd bats-core; git checkout v1.1.0; sudo ./install.sh /usr/local
-
-@test "untar and run drupal_sprint_package" {
-    rm -rf "$UNTAR_LOCATION/drupal_sprint_package"
-    tar -C "$UNTAR_LOCATION" -zxf "$SOURCE_TARBALL_LOCATION"
-    chmod -R ugo+w "$SPRINTDIR/" && rm -rf $SPRINTDIR/sprint-2* || true
-}
-
-@test "install_ddev.sh - and Sprint directories" {
-    cd $UNTAR_LOCATION/drupal_sprint_package && printf 'y\ny\n' | bash -x ./install_ddev.sh
-}
-
-@test "rm any ddev projects" {
-    ddev rm -a
-}
-
-@test "run start_sprint.sh" {
     cd $SPRINTDIR && bash -x ./start_sprint.sh
-}
-
-@test "run start_clean.sh" {
-    # Run start_clean.sh in the (only) sprint directory
     cd $SPRINTDIR/sprint-2* && echo y | ./start_clean.sh
 }
+
 
 @test "check ddev project status and router status" {
     DESCRIBE=$(cd $SPRINTDIR/sprint-2* && ddev describe -j)
@@ -61,3 +35,6 @@ function setup {
     echo "# curl: $CURL" >&3
     $CURL
 }
+
+# todo:
+# Test that drush works inside container

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -19,23 +19,6 @@ function setup {
 # choco install -y jq 7zip composer zip (gd and curl must be enabled in /c/tools/php72/php.ini)
 # apt-get install jq p7zip-full
 # git clone git://github.com/bats-core/bats-core; cd bats-core; git checkout v1.1.0; sudo ./install.sh /usr/local
-# Passwordless sudo required.
-# Developer mode enabled.
-@test "check for prereqs (docker etc)" {
-    command -v curl
-    command -v jq
-    command -v 7z
-    command -v composer
-    command -v perl
-    #  passwordless sudo ought to be available, but this command doesn't work on windows.
-    # echo junk | sudo -S ls
-    docker run --rm -t -v "/$PWD:/junk" busybox ls //junk >/dev/null
-    # Will try to get this in later.
-    # cd /tmp && rm -f junk.txt junk.txt.link && touch junk.txt && ln -s junk.txt junk.txt.link
-    # Make sure that we have symlink creation capability (Windows 10, developer mode enabled)
-    # [ -L junk.txt.link ]
-}
-
 
 @test "untar and run drupal_sprint_package" {
     rm -rf "$UNTAR_LOCATION/drupal_sprint_package"

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -4,6 +4,7 @@
 # bats tests
 
 function setup {
+    echo "# setup beginning" >&3
     export SPRINTDIR=~/sprint
     # DRUD_NONINTERACTIVE causes ddev not to try to use sudo and add the hostname
     export DRUD_NONINTERACTIVE=true
@@ -14,26 +15,32 @@ function setup {
 
     cd ${SPRINTDIR} && export SPRINT_NAME=$(./start_sprint.sh)
     cd ${SPRINTDIR}/${SPRINT_NAME} && echo y | ./start_clean.sh
+    echo "# setup complete" >&3
 }
 
 function teardown {
+    echo "# teardown beginning" >&3
+
     ddev rm -R --omit-snapshot ${SPRINT_NAME}
     if [ ! -z "${SPRINTDIR}" -a ! -z "${SPRINT_NAME}" -a -d ${SPRINTDIR}/${SPRINT_NAME} ] ; then
         rm -rf ${SPRINTDIR}/${SPRINT_NAME}
     fi
+    echo "# teardown complete" >&3
+
 }
 
 @test "check ddev project status and router status, check http status" {
-
-    [ -f ${SPRINTDIR}/SPRINTUSER_README.md -a -f ${SPRINTDIR}/COPYING -a -d ${SPRINTDIR}/licenses ]
     DESCRIBE=$(cd ${SPRINTDIR}/${SPRINT_NAME} && ddev describe -j)
+
+    echo "# Testing router status" >&3
     ROUTER_STATUS=$(echo ${DESCRIBE} | jq -r ".raw.router_status" )
     [ "$ROUTER_STATUS" = "healthy" ]
 
+    echo "# Testing project status" >&3
     STATUS=$(echo ${DESCRIBE} | jq -r ".raw.status")
     [ "$STATUS" = "running" ]
 
-    DESCRIBE=$(cd ${SPRINTDIR}/${SPRINT_NAME} && ddev describe -j)
+    echo "# Testing curl reachability" >&3
     NAME=$(echo ${DESCRIBE} | jq -r ".raw.name")
     HTTP_PORT=$(echo ${DESCRIBE} | jq -r ".raw.router_http_port")
     URL="http://${DHOST}:${HTTP_PORT}"

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -19,7 +19,7 @@ function setup {
 function teardown {
     ddev rm -R --omit-snapshot ${SPRINT_NAME}
     if [ ! -z "${SPRINTDIR}" -a ! -z "${SPRINT_NAME}" -a -d ${SPRINTDIR}/${SPRINT_NAME} ] ; then
-        rm -rf ${SPRINTDIR}/${SPRINT_NAME};
+        rm -rf ${SPRINTDIR}/${SPRINT_NAME}
     fi
 }
 

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -10,15 +10,15 @@ function setup {
     # Provide DHOST to figure out the docker host addr for curl
     DHOST=127.0.0.1
     # Extract the IP address we need from DOCKER_HOST, which is formatted like tcp://192.168.99.100:2376
-    if [ ! -z "$DOCKER_HOST" ]; then DHOST="$(echo $DOCKER_HOST | perl -p -e 's/(tcp:\/\/|:[0-9]+$)//g')"; fi
+    if [ ! -z "${DOCKER_HOST:-}" ]; then DHOST="$(echo ${DOCKER_HOST} | perl -p -e 's/(tcp:\/\/|:[0-9]+$)//g')"; fi
 
-    cd $SPRINTDIR && bash -x ./start_sprint.sh
-    cd $SPRINTDIR/sprint-2* && echo y | ./start_clean.sh
+    cd ${SPRINTDIR} && export SPRINT_NAME=$(./start_sprint.sh)
+    cd ${SPRINTDIR}/${SPRINT_NAME} && echo y | ./start_clean.sh
 }
 
 
 @test "check ddev project status and router status" {
-    DESCRIBE=$(cd $SPRINTDIR/sprint-2* && ddev describe -j)
+    DESCRIBE=$(cd ${SPRINTDIR}/${SPRINT_NAME} && ddev describe -j)
     ROUTER_STATUS=$(echo $DESCRIBE | jq -r ".raw.router_status" )
     [ "$ROUTER_STATUS" = "healthy" ]
 
@@ -27,7 +27,7 @@ function setup {
 }
 
 @test "check http status of project for 200" {
-    DESCRIBE=$(cd $SPRINTDIR/sprint-2* && ddev describe -j)
+    DESCRIBE=$(cd ${SPRINTDIR}/${SPRINT_NAME} && ddev describe -j)
     NAME=$(echo $DESCRIBE | jq -r ".raw.name")
     HTTP_PORT=$(echo $DESCRIBE | jq -r ".raw.router_http_port")
     URL="http://${DHOST}:${HTTP_PORT}"

--- a/tests/sane_testbot.sh
+++ b/tests/sane_testbot.sh
@@ -11,6 +11,12 @@ echo "sane_testbot.sh: Check to see if test machine has what it needs"
 # apt-get install jq p7zip-full
 # git clone git://github.com/bats-core/bats-core; cd bats-core; git checkout v1.1.0; sudo ./install.sh /usr/local
 
+DISK_AVAIL=$(df -k . | awk '/[0-9]%/ { gsub(/%/, ""); print $5}')
+if [ ${DISK_AVAIL} -ge 95 ] ; then
+    "echo Disk usage is ${DISK_AVAIL}% on $(hostname), not usable";
+    exit 1;
+fi
+
 for item in curl jq 7z composer perl bats; do
     command -v $item >/dev/null || ( echo "$item is not installed" && exit 2 )
 done

--- a/tests/sane_testbot.sh
+++ b/tests/sane_testbot.sh
@@ -4,7 +4,12 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-echo "sanetestbot.sh: Check to see if testbot has what it needs"
+echo "sanetestbot.sh: Check to see if test machine has what it needs"
+
+# brew install jq p7zip bats-core composer
+# choco install -y jq 7zip composer zip (gd and curl must be enabled in /c/tools/php72/php.ini)
+# apt-get install jq p7zip-full
+# git clone git://github.com/bats-core/bats-core; cd bats-core; git checkout v1.1.0; sudo ./install.sh /usr/local
 
 for item in curl jq 7z composer perl bats; do
     command -v $item >/dev/null || ( echo "$item is not installed" && exit 2 )

--- a/tests/sane_testbot.sh
+++ b/tests/sane_testbot.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+echo "sanetestbot.sh: Check to see if testbot has what it needs"
+
+for item in curl jq 7z composer perl bats; do
+    command -v $item >/dev/null || ( echo "$item is not installed" && exit 2 )
+done
+docker run --rm -t -v "/$PWD:/junk" busybox ls //junk >/dev/null || ( echo "docker is not running" && exit 3 )
+
+echo "Testbot appears to be sane"

--- a/tests/sane_testbot.sh
+++ b/tests/sane_testbot.sh
@@ -13,7 +13,7 @@ echo "sane_testbot.sh: Check to see if test machine has what it needs"
 
 DISK_AVAIL=$(df -k . | awk '/[0-9]%/ { gsub(/%/, ""); print $5}')
 if [ ${DISK_AVAIL} -ge 95 ] ; then
-    "echo Disk usage is ${DISK_AVAIL}% on $(hostname), not usable";
+    echo "Disk usage is ${DISK_AVAIL}% on $(hostname), not usable";
     exit 1;
 fi
 

--- a/tests/sane_testbot.sh
+++ b/tests/sane_testbot.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-echo "sanetestbot.sh: Check to see if test machine has what it needs"
+echo "sane_testbot.sh: Check to see if test machine has what it needs"
 
 # brew install jq p7zip bats-core composer
 # choco install -y jq 7zip composer zip (gd and curl must be enabled in /c/tools/php72/php.ini)

--- a/tests/sanetestbot.sh
+++ b/tests/sanetestbot.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-echo "sane_testbot.sh: Check to see if test machine has what it needs"
+echo "sanetestbot.sh: Check to see if test machine has what it needs"
 
 # brew install jq p7zip bats-core composer
 # choco install -y jq 7zip composer zip (gd and curl must be enabled in /c/tools/php72/php.ini)

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -14,7 +14,7 @@ export DDEV_INSTALL_DIR=~/tmp/quicksprintbin
 # Add /usr/local/bin to path for git-bash, where it may not exist.
 export PATH="$PATH:/usr/local/bin"
 
-tests/sane_testbot.sh || ( echo "sane_testbot.sh failed, test machine is not ready for duty" && exit 1 )
+tests/sanetestbot.sh || ( echo "sanetestbot.sh failed, test machine is not ready for duty" && exit 1 )
 
 function cleanup {
     rm -rf /tmp/drupal_sprint_package

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -10,6 +10,9 @@ export SPRINTDIR=~/sprint
 export QUICKSPRINT_RELEASE=$(cat .quicksprint_release.txt)
 export DDEV_INSTALL_DIR=~/tmp/quicksprintbin
 
+# Add /usr/local/bin to path for git-bash, where it may not exist.
+export PATH="$PATH:/usr/local/bin"
+
 tests/sane_testbot.sh || ( echo "sane_testbot.sh failed, test machine is not ready for duty" && exit 1 )
 
 # Clean up any previous existing stuff

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-set -o errexit
+#set -o errexit
 set -o pipefail
 set -o nounset
 
 # This should be run from the repo root
+
+if ! tests/sanetestbot.sh ; then
 
 export PATH="/usr/local/bin:$PATH"
 bats tests

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -6,6 +6,7 @@ set -o nounset
 
 # This test script should be run from the repo root
 UNTAR_LOCATION=/tmp
+UNTARRED_PACKAGE=$UNTAR_LOCATION/drupal_sprint_package
 export SPRINTDIR=~/sprint
 export QUICKSPRINT_RELEASE=$(cat .quicksprint_release.txt)
 export DDEV_INSTALL_DIR=~/tmp/quicksprintbin
@@ -24,7 +25,7 @@ trap cleanup EXIT
 
 # Clean up any previous existing stuff
 (chmod -R ugo+w "$SPRINTDIR/" && rm -rf  ${SPRINTDIR}/sprint-2* ) || true
-rm -rf "$UNTAR_LOCATION/drupal_sprint_package"
+rm -rf "$UNTARRED_PACKAGE"
 
 echo n | ./package_drupal_script.sh || ( echo "package_drupal_script.sh failed" && exit 2 )
 # SOURCE_TARBALL_LOCATION isn't valid until package_drupal_script has run.
@@ -33,13 +34,13 @@ SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_docker.${QUICKSPRINT_RELE
 # Untar source tarball
 tar -C "$UNTAR_LOCATION" -zxf $SOURCE_TARBALL_LOCATION
 
-if [ ! -f ${SPRINTDIR}/SPRINTUSER_README.md -o ! -f ${SPRINTDIR}/COPYING -o ! -d ${SPRINTDIR}/licenses ]; then
-    echo "Packaged documents are missing from sprint package"
+if [ ! -f "$UNTARRED_PACKAGE/SPRINTUSER_README.md" -o ! -f "$UNTARRED_PACKAGE/COPYING" -o ! -d "$UNTARRED_PACKAGE/licenses" ]; then
+    echo "Packaged documents are missing from sprint package (in $UNTARRED_PACKAGE)"
     exit 3
 fi
 
 # Run install_ddev.sh
-(cd "${UNTAR_LOCATION}/drupal_sprint_package" && printf 'y\ny\n' | ./install_ddev.sh) || ( echo "Failed to install_ddev.sh" && exit 4 )
+(cd "$UNTARRED_PACKAGE" && printf 'y\ny\n' | ./install_ddev.sh) || ( echo "Failed to install_ddev.sh" && exit 4 )
 
 # Stop any running ddev instances, if we can
 ddev rm -a

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -15,6 +15,13 @@ export PATH="$PATH:/usr/local/bin"
 
 tests/sane_testbot.sh || ( echo "sane_testbot.sh failed, test machine is not ready for duty" && exit 1 )
 
+function cleanup {
+    rm -rf /tmp/drupal_sprint_package
+    if [ ! -z "$SOURCE_TARBALL_LOCATION" ] ; then rm -f ${SOURCE_TARBALL_LOCATION}; fi
+}
+trap cleanup EXIT
+
+
 # Clean up any previous existing stuff
 (chmod -R ugo+w "$SPRINTDIR/" && rm -rf  ${SPRINTDIR}/sprint-2* ) || true
 rm -rf "$UNTAR_LOCATION/drupal_sprint_package"
@@ -24,19 +31,21 @@ echo n | ./package_drupal_script.sh || ( echo "package_drupal_script.sh failed" 
 SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
 
 # Untar source tarball
-tar -C "$UNTAR_LOCATION" -zxf "$SOURCE_TARBALL_LOCATION"
+tar -C "$UNTAR_LOCATION" -zxf $SOURCE_TARBALL_LOCATION
+
+if [ ! -f ${SPRINTDIR}/SPRINTUSER_README.md -o ! -f ${SPRINTDIR}/COPYING -o ! -d ${SPRINTDIR}/licenses ]; then
+    echo "Packaged documents are missing from sprint package"
+    exit 3
+fi
 
 # Run install_ddev.sh
-(cd "${UNTAR_LOCATION}/drupal_sprint_package" && printf 'y\ny\n' | ./install_ddev.sh) || ( echo "Failed to install_ddev.sh" && exit 3 )
+(cd "${UNTAR_LOCATION}/drupal_sprint_package" && printf 'y\ny\n' | ./install_ddev.sh) || ( echo "Failed to install_ddev.sh" && exit 4 )
 
 # Stop any running ddev instances, if we can
 ddev rm -a
 
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"
-bats tests || ( echo "bats tests failed" && exit 4 )
-
-# rm -rf /tmp/drupal_sprint_package
-rm "${SOURCE_TARBALL_LOCATION}"
+bats tests || ( echo "bats tests failed" && exit 5 )
 
 echo "Test successful"

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -5,6 +5,7 @@ set -o pipefail
 set -o nounset
 
 # This should be run from the repo root
+
 export PATH="/usr/local/bin:$PATH"
 bats tests
 

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -1,16 +1,38 @@
 #!/bin/bash
 
-#set -o errexit
+set -o errexit
 set -o pipefail
 set -o nounset
 
-# This should be run from the repo root
+# This test script should be run from the repo root
+UNTAR_LOCATION=/tmp
+export SPRINTDIR=~/sprint
+export QUICKSPRINT_RELEASE=$(cat .quicksprint_release.txt)
+SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
+export DDEV_INSTALL_DIR=~/tmp/quicksprintbin
 
-if ! tests/sanetestbot.sh ; then
+tests/sane_testbot.sh || ( echo "sane_testbot.sh failed, test machine is not ready for duty" && exit 1 )
 
+# Clean up any previous existing stuff
+(chmod -R ugo+w "$SPRINTDIR/" && rm -rf  ${SPRINTDIR}/sprint-2* ) || true
+rm -rf "$UNTAR_LOCATION/drupal_sprint_package"
+
+echo n | ./package_drupal_script.sh || ( echo "package_drupal_script.sh failed" && exit 2 )
+
+# Untar source tarball
+tar -C "$UNTAR_LOCATION" -zxf "$SOURCE_TARBALL_LOCATION"
+
+# Run install_ddev.sh
+(cd "${UNTAR_LOCATION}/drupal_sprint_package" && printf 'y\ny\n' | ./install_ddev.sh) || ( echo "Failed to install_ddev.sh" && exit 3 )
+
+# Stop any running ddev instances, if we can
+ddev rm -a
+
+# /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"
-bats tests
+bats tests || ( echo "bats tests failed" && exit 4 )
 
 # rm -rf /tmp/drupal_sprint_package
+rm "${SOURCE_TARBALL_LOCATION}"
 
 echo "Test successful"

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -8,7 +8,6 @@ set -o nounset
 UNTAR_LOCATION=/tmp
 export SPRINTDIR=~/sprint
 export QUICKSPRINT_RELEASE=$(cat .quicksprint_release.txt)
-SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
 export DDEV_INSTALL_DIR=~/tmp/quicksprintbin
 
 tests/sane_testbot.sh || ( echo "sane_testbot.sh failed, test machine is not ready for duty" && exit 1 )
@@ -18,6 +17,8 @@ tests/sane_testbot.sh || ( echo "sane_testbot.sh failed, test machine is not rea
 rm -rf "$UNTAR_LOCATION/drupal_sprint_package"
 
 echo n | ./package_drupal_script.sh || ( echo "package_drupal_script.sh failed" && exit 2 )
+# SOURCE_TARBALL_LOCATION isn't valid until package_drupal_script has run.
+SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
 
 # Untar source tarball
 tar -C "$UNTAR_LOCATION" -zxf "$SOURCE_TARBALL_LOCATION"


### PR DESCRIPTION
Up to now, the bats test were dependent on each other, but we need to make them just dependent on their own setup. This moves the basic build and install into the test script.