### PR TITLE
Clean up sprint packages on buildkite build

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -6,6 +6,7 @@ set -o nounset
 
 echo "--- buildkite building at $(date) on $(hostname) for OS=$(go env GOOS) in $PWD"
 echo "--- package_drupal_script.sh"
+rm -f ~/tmp/drupal_sprint_package*gz ~/tmp/drupal_sprint_package*zip
 echo "n" | ./package_drupal_script.sh
 echo "--- test_drupal_quicksprint.sh"
 tests/test_drupal_quicksprint.sh


### PR DESCRIPTION
The testbot is getting disk space problems fast on win10home, need to clean up.