### PR TITLE
Get latest docker toolbox and git for windows, fixes #94

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -23,7 +23,14 @@ QUICKSPRINT_RELEASE=$(git describe --tags --always --dirty)
 
 echo "$QUICKSPRINT_RELEASE" >.quicksprint_release.txt
 
-DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe https://github.com/docker/toolbox/releases/download/v18.06.0-ce/DockerToolbox-18.06.0-ce.exe https://github.com/git-for-windows/git/releases/download/v2.18.0.windows.1/Git-2.18.0-64-bit.exe"
+TOOLBOX_LATEST_RELEASE="$(curl -L -s -H 'Accept: application/json' https://github.com/docker/toolbox/releases/latest | jq -r .tag_name | sed 's/^v//')"
+TOOLBOX_DOWNLOAD_URL="https://github.com/docker/toolbox/releases/download/v${TOOLBOX_LATEST_RELEASE}/DockerToolbox-${TOOLBOX_LATEST_RELEASE}.exe"
+
+GIT_LATEST_RELEASE="$(curl -L -s -H 'Accept: application/json' https://github.com/git-for-windows/git/releases/latest | jq -r .tag_name | sed 's/^v//; s/\.windows\.1//;')"
+GIT_DOWNLOAD_URL="https://github.com/git-for-windows/git/releases/download/v${GIT_LATEST_RELEASE}.windows.1/Git-${GIT_LATEST_RELEASE}-64-bit.exe"
+
+
+DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe ${TOOLBOX_DOWNLOAD_URL} ${GIT_DOWNLOAD_URL}"
 
 RED='\033[31m'
 GREEN='\033[32m'
@@ -86,14 +93,14 @@ while true; do
         [Yy]* ) printf "${GREEN}# Downloading installers. \n#### \n${RESET}";
                 mkdir -p installs
                 pushd installs >/dev/null
-                for dockerurl in ${DOWNLOAD_URLS}; do
-                    echo "Downloading ${dockerurl##*/} from ${dockerurl}"
-                    curl -sSL -O ${dockerurl}
+                for download_url in ${DOWNLOAD_URLS}; do
+                    echo "Downloading ${download_url##*/} from ${download_url}"
+                    curl -sSL -O ${download_url}
                 done
                 popd >/dev/null
                 break;;
 
-        [Nn]* ) printf "${GREEN}# Continuing script without downloading Docker installers. \n### \n${RESET}"; 
+        [Nn]* ) printf "${GREEN}# Continuing script without downloading installers. \n### \n${RESET}";
                 break;;
 
         * ) echo "Please answer y or n.";;
@@ -114,7 +121,7 @@ ${SHACMD} -c "$SHAFILE"
 popd >/dev/null
 
 # Download the ddev tarball/zipball
-for item in macos linux windows windows_installer; do
+for item in macos linux windows_installer; do
     SUFFIX=tar.gz
     if [ ${item} == "windows_installer" ] ; then
         SUFFIX=exe

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -121,7 +121,7 @@ ${SHACMD} -c "$SHAFILE"
 popd >/dev/null
 
 # Download the ddev tarball/zipball
-for item in macos linux windows_installer; do
+for item in macos linux windows windows_installer; do
     SUFFIX=tar.gz
     if [ ${item} == "windows_installer" ] ; then
         SUFFIX=exe

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -29,10 +29,11 @@ function teardown {
 }
 
 @test "check ddev project status and router status, check http status" {
-    DESCRIBE=$(cd ${SPRINTDIR}/${SPRINT_NAME} && ddev describe -j)
+    cd ${SPRINTDIR}/${SPRINT_NAME}
+    DESCRIBE=$(ddev describe -j)
 
-    echo "# Testing router status" >&3
-    ROUTER_STATUS=$(echo ${DESCRIBE} | jq -r ".raw.router_status" )
+    ROUTER_STATUS=$(echo "${DESCRIBE}" | jq -r ".raw.router_status" )
+    echo "# Test router status (${ROUTER_STATUS})" >&3
     if [ "$ROUTER_STATUS" != "healthy" ] ; then
         echo "# Router status not healthy (${ROUTER_STATUS})" >&3
         echo "# Full DESCRIBE=${DESCRIBE}" >&3

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -33,7 +33,11 @@ function teardown {
 
     echo "# Testing router status" >&3
     ROUTER_STATUS=$(echo ${DESCRIBE} | jq -r ".raw.router_status" )
-    [ "$ROUTER_STATUS" = "healthy" ]
+    if [ "$ROUTER_STATUS" != "healthy" ] ; then
+        echo "# Router status not healthy (${ROUTER_STATUS})" >&3
+        ddev list >&3;
+        return 101
+    fi
 
     echo "# Testing project status" >&3
     STATUS=$(echo ${DESCRIBE} | jq -r ".raw.status")

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -35,6 +35,7 @@ function teardown {
     ROUTER_STATUS=$(echo ${DESCRIBE} | jq -r ".raw.router_status" )
     if [ "$ROUTER_STATUS" != "healthy" ] ; then
         echo "# Router status not healthy (${ROUTER_STATUS})" >&3
+        echo "# Full DESCRIBE=${DESCRIBE}" >&3
         ddev list >&3;
         return 101
     fi


### PR DESCRIPTION
* Use github API to determine latest docker-toolbox and git-for-windows version for download.
* Stop bundling ddev_windows.tar.gz, which I don't think anybody (should) use any more.

To review, download the artifacts created in circleci and see if they are the right ones.