### PR TITLE
Use ddev --project-name; split out actions for better user feedback. Fixes #100, fixes #99, fixes #103

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ ${GREEN}
 ${RESET}"
 
 echo ""
-echo "Installing docker images for ddev to use..."
+printf "Installing docker images for ddev to use...\n"
 
 if command -v xzcat >/dev/null; then
     xzcat ddev_tarballs/ddev_docker_images*.tar.xz | docker load

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -70,7 +70,7 @@ if [ -d $ddev_tarballs ] && (ls $ddev_tarballs/* | grep -v ${LATEST_VERSION}) ; 
 fi
 
 # Install the beginning items we need in the kit.
-cp -r .ddev_version.txt .quicksprint_release.txt sprint start_sprint.* SPRINTUSER_README.md install.sh ${STAGING_DIR}
+cp -r .ddev_version.txt .quicksprint_release.txt sprint start_sprint.* *.md install.sh ${STAGING_DIR}
 
 
 # macOS/Darwin has a oneoff/weird shasum command.

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -50,13 +50,6 @@ else
     exit 1
 fi
 
-
-if [ -d "$STAGING_DIR" ] && [ ! -z "$(ls -A "$STAGING_DIR")" ] ; then
-    printf "${RED}The staging directory $STAGING_DIR already has files. Deleting them and recreating everything.${RESET}"
-    rm -rf "$STAGING_DIR"
-    rm -f $STAGING_DIR_BASE/drupal_sprint_package.*.${QUICKSPRINT_RELEASE}.*
-fi
-
 SHACMD="sha256sum"
 LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/drud/ddev/releases/latest)
 # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
@@ -65,8 +58,18 @@ RELEASE_URL="https://github.com/drud/ddev/releases/download/$LATEST_VERSION"
 
 echo "$LATEST_VERSION" >.ddev_version.txt
 
+# Remove anything in the ddev_tarballs directory that don't match current version.
+ddev_tarballs="${STAGING_DIR}/ddev_tarballs"
+mkdir -p ${ddev_tarballs}
+
+# Remove anything in staging directory except ddev_tarballs.
+rm -rf "${STAGING_DIR}/{*.md,install.sh,sprint,start_sprint.sh}"
+# Remove anytyhing in ddev_tarballs that is not the latest version
+if [ -d $ddev_tarballs ] && (ls $ddev_tarballs/* | grep -v ${LATEST_VERSION}) ; then
+    rm $(ls $ddev_tarballs/* | grep -v ${LATEST_VERSION})
+fi
+
 # Install the beginning items we need in the kit.
-mkdir -p ${STAGING_DIR}
 cp -r .ddev_version.txt .quicksprint_release.txt sprint start_sprint.* SPRINTUSER_README.md install.sh ${STAGING_DIR}
 
 
@@ -76,7 +79,7 @@ if [ "$OS" = "Darwin" ]; then
 fi
 
 if ! docker --version >/dev/null 2>&1; then
-    printf "${YELLOW}Docker is required to use this package. Please install docker before attempting to use ddev.${RESET}\n"
+    printf "${YELLOW}Docker is required to create package. Please install docker before attempting to use ddev.${RESET}\n"
 fi
 
 cd ${STAGING_DIR}
@@ -108,36 +111,19 @@ while true; do
     esac
 done
 
-mkdir -p ddev_tarballs
-TARBALL="ddev_docker_images.$LATEST_VERSION.tar.xz"
-SHAFILE="$TARBALL.sha256.txt"
-if [ ! -f "ddev_tarballs/$TARBALL" ] ; then
-    echo "Downloading $TARBALL ..."
-    curl --fail -sSL "$RELEASE_URL/$TARBALL" -o "ddev_tarballs/$TARBALL"
-    curl --fail -sSL "$RELEASE_URL/$SHAFILE" -o "ddev_tarballs/$SHAFILE"
-fi
-pushd ddev_tarballs >/dev/null
-${SHACMD} -c "$SHAFILE"
-popd >/dev/null
+pushd ${ddev_tarballs} >/dev/null
+# Download the ddev tarballs if necessary; check to make sure they all have correct sha256.
+for tarball in ddev_macos.$LATEST_VERSION.tar.gz ddev_linux.$LATEST_VERSION.tar.gz ddev_windows.$LATEST_VERSION.tar.gz ddev_windows_installer.$LATEST_VERSION.exe ddev_docker_images.$LATEST_VERSION.tar.xz; do
+    shafile="${tarball}.sha256.txt"
 
-# Download the ddev tarball/zipball
-for item in macos linux windows windows_installer; do
-    SUFFIX=tar.gz
-    if [ ${item} == "windows_installer" ] ; then
-        SUFFIX=exe
+    if ! [ -f "${tarball}" -a -f "${shafile}" ] ; then
+        echo "Downloading ${tarball} ..."
+        curl --fail -sSL "$RELEASE_URL/${tarball}" -o "${tarball}"
+        curl --fail -sSL "$RELEASE_URL/$shafile" -o "${shafile}"
     fi
-    TARBALL="ddev_$item.$LATEST_VERSION.$SUFFIX"
-    SHAFILE="$TARBALL.sha256.txt"
-
-    if [ ! -f "ddev_tarballs/$TARBALL" ] ; then
-        echo "Downloading $TARBALL ..."
-        curl --fail -sSL "$RELEASE_URL/$TARBALL" -o "ddev_tarballs/$TARBALL"
-        curl --fail -sSL "$RELEASE_URL/$SHAFILE" -o "ddev_tarballs/$SHAFILE"
-    fi
-    pushd ddev_tarballs >/dev/null
-    ${SHACMD} -c $(basename "$SHAFILE")
-    popd >/dev/null
+    ${SHACMD} -c "${shafile}"
 done
+popd >/dev/null
 
 # clone or refresh d8 clone
 mkdir -p sprint
@@ -172,11 +158,5 @@ zip -9 -r -q drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.zip ${STAGIN
 printf "${GREEN}####
 # The built sprint tarballs and zipballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}.
 #
-# Now deleting the staging directory.
+# Package is built, staging directory remains in ${STAGING_DIR}.
 ####${RESET}"
-rm -rf ${STAGING_DIR_NAME}
-
-printf "${GREEN}
-# Finished
-####${RESET}
-"

--- a/sprint/.ddev/config.yaml
+++ b/sprint/.ddev/config.yaml
@@ -1,4 +1,4 @@
-APIVersion: v1.0.0
+APIVersion: v1.5.2
 name: sprint-[ts]
 type: drupal8
 docroot: drupal8
@@ -6,28 +6,28 @@ php_version: "7.2"
 router_http_port: "8080"
 router_https_port: "8443"
 xdebug_enabled: false
-additional_hostnames: []
-additional_fqdns: []
 provider: default
 
-# This config.yaml was created with ddev version v1.0.0
-# webimage: drud/ddev-webserver:v1.0.0
-# dbimage: drud/ddev-dbserver:v1.0.0
-# dbaimage: drud/phpmyadmin:v1.0.0
+
+# This config.yaml was created with ddev version v1.5.2
+# webimage: drud/ddev-webserver:v1.5.2
+# dbimage: drud/ddev-dbserver:v1.5.2-10.2
+# dbaimage: drud/phpmyadmin:v1.5.2
+# bgsyncimage: drud/ddev-bgsync:v1.5.2
 # However we do not recommend explicitly wiring these images into the
 # config.yaml as they may break future versions of ddev.
 # You can update this config.yaml using 'ddev config'.
 
 # Key features of ddev's config.yaml:
 
-# name: <projectname> # Name of the project, automatically provides
+# name: <project-name> # Name of the project, automatically provides
 #   http://projectname.ddev.local and https://projectname.ddev.local
 
 # type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "7.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2"
+# php_version: "7.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3"
 
 # You can explicitly specify the webimage, dbimage, dbaimage lines but this
 # is not recommended, as the images are often closely tied to ddev's' behavior,
@@ -36,29 +36,49 @@ provider: default
 # webimage: <docker_image>  # nginx/php docker image.
 # dbimage: <docker_image>  # mariadb docker image.
 # dbaimage: <docker_image>
+# bgsyncimage: <docker_image>
 
 # router_http_port: <port>  # Port to be used for http (defaults to port 80)
 # router_https_port: <port> # Port for https (defaults to 443)
 
 # xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
 
-#additional_hostnames:
-# - somename
-# - someothername
+# webserver_type: nginx-fpm  # Can be set to apache-fpm or apache-cgi as well
+
+# additional_hostnames:
+#  - somename
+#  - someothername
 # would provide http and https URLs for "somename.ddev.local"
 # and "someothername.ddev.local".
 
-#additional_fqdns:
-# - example.com
-# - sub1.example.com
+# additional_fqdns:
+#  - example.com
+#  - sub1.example.com
 # would provide http and https URLs for "example.com" and "sub1.example.com"
 # Please take care with this because it can cause great confusion.
+
+# upload_dir: custom/upload/dir
+# would set the destination path for ddev import-files to custom/upload/dir.
+
+# working_dir:
+#   web: /var/www/html
+#   db: /home
+# would set the default working directory for the web and db services.
+# These values specify the destination directory for ddev ssh and the
+# directory in which commands passed into ddev exec are run.
+
+# omit_containers: ["dba", "ddev-ssh-agent"]
+# would omit the dba (phpMyAdmin) and ddev-ssh-agent containers. Currently
+# only those two containers can be omitted here.
+# Note that these containers can also be omitted globally in the
+# ~/.ddev/global_config.yaml or with the "ddev config global" command.
+
 
 # provider: default # Currently either "default" or "pantheon"
 #
 # Many ddev commands can be extended to run tasks after the ddev command is
 # executed.
-# See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more
+# See https://ddev.readthedocs.io/en/stable/users/extending-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them. Example:
 #hooks:

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -42,7 +42,7 @@ done
 echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which ddev)"
 
 # Attempts to reconfigure ddev to update config automagically.
-ddev config --docroot drupal8 --projectname sprint-[ts] --projecttype drupal8
+ddev config --docroot drupal8 --project-name sprint-[ts] --project-type drupal8
 
 echo "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}"
 ddev start

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -50,11 +50,11 @@ printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minut
 printf "${YELLOW}Running ddev start...${RESET}\n"
 ddev start >ddev_start.txt 2>&1
 printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}...\n"
-time ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'"
+ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'"
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
-time ddev composer install -d drupal8
+ddev composer install -d drupal8
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
-time ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting"
+ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting"
 printf "${RESET}"
 ddev describe
 

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SPRINT_BRANCH=8.7.x
+
 set -o errexit
 set -o pipefail
 set -o nounset
@@ -45,8 +47,14 @@ echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which 
 ddev config --docroot drupal8 --project-name sprint-[ts] --project-type drupal8
 
 echo "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}"
-ddev start
-ddev exec bash -c 'git fetch && git reset --hard origin/8.7.x && composer install && drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting" && drush cr'
+echo "${YELLOW}Running ddev start.${RESET}"
+ddev start >ddev_start.txt 2>&1
+echo "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}"
+ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'
+echo "${YELLOW}Running 'ddev composer install'${RESET}"
+ddev composer install
+echo "${YELLOW}Running 'drush si' to install drupal.${RESET}"
+ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting"
 printf "${RESET}"
 ddev describe
 

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -46,15 +46,15 @@ echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which 
 # Attempts to reconfigure ddev to update config automagically.
 ddev config --docroot drupal8 --project-name sprint-[ts] --project-type drupal8
 
-echo "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}"
-echo "${YELLOW}Running ddev start.${RESET}"
+printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}\n"
+printf "${YELLOW}Running ddev start...${RESET}\n"
 ddev start >ddev_start.txt 2>&1
-echo "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}"
-ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'"
-echo "${YELLOW}Running 'ddev composer install'${RESET}"
-ddev composer install -d drupal8
-echo "${YELLOW}Running 'drush si' to install drupal.${RESET}"
-ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting"
+printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}...\n"
+time ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'"
+printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
+time ddev composer install -d drupal8
+printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
+time ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting"
 printf "${RESET}"
 ddev describe
 

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -50,7 +50,7 @@ echo "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes
 echo "${YELLOW}Running ddev start.${RESET}"
 ddev start >ddev_start.txt 2>&1
 echo "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}"
-ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'
+ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'"
 echo "${YELLOW}Running 'ddev composer install'${RESET}"
 ddev composer install
 echo "${YELLOW}Running 'drush si' to install drupal.${RESET}"

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -52,7 +52,7 @@ ddev start >ddev_start.txt 2>&1
 echo "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}"
 ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'"
 echo "${YELLOW}Running 'ddev composer install'${RESET}"
-ddev composer install
+ddev composer install -d drupal8
 echo "${YELLOW}Running 'drush si' to install drupal.${RESET}"
 ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting"
 printf "${RESET}"

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -22,7 +22,7 @@ tests/sanetestbot.sh || ( echo "sanetestbot.sh failed, test machine is not ready
 
 function cleanup {
     rm -rf /tmp/drupal_sprint_package
-    if [ ! -z "$SOURCE_TARBALL_LOCATION" ] ; then rm -f ${SOURCE_TARBALL_LOCATION}; fi
+    if [ ! -z "${SOURCE_TARBALL_LOCATION:-}" ] ; then rm -f ${SOURCE_TARBALL_LOCATION:-nopedontrm}; fi
 }
 trap cleanup EXIT
 
@@ -36,7 +36,7 @@ echo n | ./package_drupal_script.sh || ( echo "package_drupal_script.sh failed" 
 SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
 
 # Untar source tarball
-tar -C "$UNTAR_LOCATION" -zxf $SOURCE_TARBALL_LOCATION
+tar -C "$UNTAR_LOCATION" -zxf ${SOURCE_TARBALL_LOCATION:-}
 
 if [ ! -f "$UNTARRED_PACKAGE/SPRINTUSER_README.md" -o ! -f "$UNTARRED_PACKAGE/COPYING" -o ! -d "$UNTARRED_PACKAGE/licenses" ]; then
     echo "Packaged documents are missing from sprint package (in $UNTARRED_PACKAGE)"


### PR DESCRIPTION
I apologize that this PR got out of control. I ended up trying to fix one thing and then another, and of course and just re-familiarizing myself. I think it's improved quite a lot with this PR, but it unfortunately didn't stay with one small change, which was the intent.

* script was using ddev config --projectname, current preferred is ddev config --project-name #100 
* Install components (git fetch/checkout/composer install/drush si) broken out into separate steps to give better user feedback #99 
* Minor cosmetic updates to default config.yaml
* #103: Allow it to keep ddev tarballs around if they're the right version. Circleci won't, they'll be downloaded and built from scratch there. But at least not re-built for tests.

IMO this can be tested by reviewing the build log and installing from the [circle-ci-built package](https://circleci.com/gh/drud/quicksprint/768#artifacts/containers/0) as a test. 