### PR TITLE
Stop using GZIP options variable since it's deprecated, fixes #106

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -147,7 +147,7 @@ rm -rf ${STAGING_DIR}/sprint
 
 cd ${STAGING_DIR_BASE}
 if [ "$INSTALL" != "n" ] ; then
-    tar -cf - ${STAGING_DIR_NAME} | gzip -9 >drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz 
+    tar -cf - ${STAGING_DIR_NAME} | gzip -9 >drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz
     zip -9 -r -q drupal_sprint_package.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
 fi
 rm -rf ${STAGING_DIR_NAME}/installs

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -10,7 +10,6 @@ export MSYS=winsymlinks:nativestrict
 
 # Maximise compression
 export XZ_OPT=-9e
-export GZIP=-9
 
 # This script creates a package of artifacts that can then be used at a code sprint working on Drupal 8.
 # It assumes it's being run in the repository root.
@@ -148,11 +147,11 @@ rm -rf ${STAGING_DIR}/sprint
 
 cd ${STAGING_DIR_BASE}
 if [ "$INSTALL" != "n" ] ; then
-    tar -czf drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz ${STAGING_DIR_NAME}
+    tar -cf - ${STAGING_DIR_NAME} | gzip -9 >drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz 
     zip -9 -r -q drupal_sprint_package.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
 fi
 rm -rf ${STAGING_DIR_NAME}/installs
-tar -czf drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz ${STAGING_DIR_NAME}
+tar -cf - ${STAGING_DIR_NAME} | gzip -9 > drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
 zip -9 -r -q drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
 
 printf "${GREEN}####

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -48,9 +48,9 @@ ddev config --docroot drupal8 --project-name sprint-[ts] --project-type drupal8
 
 printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}\n"
 printf "${YELLOW}Running ddev start...${RESET}\n"
-ddev start >ddev_start.txt 2>&1
+ddev start >ddev_start.txt 2>&1 || (echo "ddev start failed: $(cat ddev_start.txt)" && exit 101)
 printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}...\n"
-ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'"
+ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'" || (echo "ddev exec bash...git reset failed" && exit 102)
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
 ddev composer install -d drupal8
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"


### PR DESCRIPTION
$GZIP is apparently deprecated, at least with some versions of gzip/tar.

[Stack overflow article](https://superuser.com/questions/305128/how-to-specify-level-of-compression-when-using-tar-zcvf/1396116#1396116) has many solutions, but they vary by platform. I even added one there for macOS, but it doesn't work anywhere else. So I used `    tar -cf - ${STAGING_DIR_NAME} | gzip -9 >drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz` as the most general solution.