### PR TITLE
Specify git core.autocrlf=false and core.eol=lf on checkout, fixes #83

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ if command -v xzcat >/dev/null; then
 elif [[ "$OS" == "Darwin" ]]; then
     gzip -dc ddev_tarballs/ddev_docker_images*.tar.xz | docker load
 else
-    echo "${YELLOW}Unable to load ddev_docker_images. They will load at first 'ddev start'.${RESET}"
+    printf "${YELLOW}Unable to load ddev_docker_images. They will load at first 'ddev start'.${RESET}\n"
 fi
 
 
@@ -65,10 +65,10 @@ case "$OS" in
     MINGW64_NT*)
         echo ""
         TARBALL=ddev_tarballs/ddev_windows.${DDEV_VERSION}.tar.gz
-        printf "${YELLOW}Please use the ddev_windows_installer provided with this package to install ddev${RESET}"
+        printf "${YELLOW}Please use the ddev_windows_installer provided with this package to install ddev${RESET}\n"
         ;;
     *)
-        echo "${RED}No ddev binary is available for ${OS}${RESET}"
+        printf "${RED}No ddev binary is available for ${OS}${RESET}\n"
         exit 2
         ;;
 

--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,7 @@ if [ ! -z "$TARBALL" ] ; then
     chmod ugo+x /tmp/ddev
 
     if command -v ddev >/dev/null && [  -z "${DDEV_INSTALL_DIR:-}" ] ; then
-        printf "${RED}A version of ddev already exists in $(command -v ddev); You may upgrade it using your normal upgrade technique. Not installing a new version.${RESET}"
+        printf "\n${RED}A version of ddev already exists in $(command -v ddev); You may upgrade it using your normal upgrade technique. Not installing a new version.${RESET}\n"
     else
         # Calling script may have already set DDEV_INSTALL_DIR, otherwise we respect and use it.
         if [ ! -z "${DDEV_INSTALL_DIR:-}" ]; then
@@ -122,6 +122,6 @@ ${GREEN}
 ${RESET}
 "
 
-if ! command -v ddev >/dev/null && [ "${OS}" = "MINGW64_NT*" ] ; then
-    printf "${RED}ddev has not yet been installed. Please use the ddev_windows_installer to install it${RESET}"
+if ! command -v ddev >/dev/null && [ "${OS}" =~ "MINGW64_NT*" ] ; then
+    printf "${RED}ddev has not yet been installed. Please use the ddev_windows_installer to install it${RESET}\n"
 fi

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ case "$OS" in
     MINGW64_NT*)
         echo ""
         TARBALL=ddev_tarballs/ddev_windows.${DDEV_VERSION}.tar.gz
-        echo "${YELLOW}Please use the ddev_windows_installer provided with this package to install ddev${RESET}"
+        printf "${YELLOW}Please use the ddev_windows_installer provided with this package to install ddev${RESET}"
         ;;
     *)
         echo "${RED}No ddev binary is available for ${OS}${RESET}"

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+# Base checkout should be of the 8.7.x branch
+SPRINT_BRANCH=8.7.x
+
 # This makes git-bash actually try to create symlinks.
 # Use developer mode in Windows 10 so this doesn't require admin privs.
 export MSYS=winsymlinks:nativestrict
@@ -126,7 +129,7 @@ popd >/dev/null
 
 # clone or refresh d8 clone
 mkdir -p sprint
-git clone --config core.autocrlf=false --config core.eol=lf --quiet https://git.drupal.org/project/drupal.git ${STAGING_DIR}/sprint/drupal8
+git clone --config core.autocrlf=false --config core.eol=lf --quiet https://git.drupal.org/project/drupal.git ${STAGING_DIR}/sprint/drupal8 -b ${SPRINT_BRANCH}
 pushd ${STAGING_DIR}/sprint/drupal8 >/dev/null
 cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -126,7 +126,7 @@ popd >/dev/null
 
 # clone or refresh d8 clone
 mkdir -p sprint
-git clone --quiet https://git.drupal.org/project/drupal.git ${STAGING_DIR}/sprint/drupal8
+git clone --config core.autocrlf=false --config core.eol=lf --quiet https://git.drupal.org/project/drupal.git ${STAGING_DIR}/sprint/drupal8
 pushd ${STAGING_DIR}/sprint/drupal8 >/dev/null
 cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -143,17 +143,19 @@ cp ${REPO_DIR}/.quicksprint_release.txt $REPO_DIR/.ddev_version.txt "$STAGING_DI
 
 cd ${STAGING_DIR}
 
-echo "Creating tar and zipballs"
+echo "Creating sprint.tar.xz..."
 # Create tar.xz archive using xz command, so we can work on all platforms
-pushd sprint >/dev/null && tar -cJf ../sprint.tar.xz . && popd >/dev/null
+pushd sprint >/dev/null && tar -cvJf ../sprint.tar.xz . && popd >/dev/null
 rm -rf ${STAGING_DIR}/sprint
 
 cd ${STAGING_DIR_BASE}
 if [ "$INSTALL" != "n" ] ; then
+    echo "Creating drupal_sprint_package with installs..."
     tar -cf - ${STAGING_DIR_NAME} | gzip -9 >drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz
     zip -9 -r -q drupal_sprint_package.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
 fi
 rm -rf ${STAGING_DIR_NAME}/installs
+echo "Creating no-docker sprint package..."
 tar -cf - ${STAGING_DIR_NAME} | gzip -9 > drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
 zip -9 -r -q drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
 

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -62,7 +62,7 @@ ddev_tarballs="${STAGING_DIR}/ddev_tarballs"
 mkdir -p ${ddev_tarballs}
 
 # Remove anything in staging directory except ddev_tarballs.
-rm -rf "${STAGING_DIR}/{*.md,install.sh,sprint,start_sprint.sh}"
+rm -rf ${STAGING_DIR}/{*.md,install.sh,sprint,start_sprint.sh}
 # Remove anything in ddev_tarballs that is not the latest version
 if [ -d "${ddev_tarballs}" ]; then
      find "${ddev_tarballs}" -type f -not -name "*${LATEST_VERSION}*" -exec rm '{}' \;

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -42,7 +42,7 @@ OS=$(uname)
 USER=$(whoami)
 
 # Ensure zcat is installed
-command -v zcat >/dev/null 2>&1 || { echo >&2 "${RED}zcat command is required but it's not installed. ('brew install xz' on macOS, 'apt-get install xz-utils' on Debian/Ubuntu) Aborting.${RESET}"; exit 1; }
+command -v zcat >/dev/null 2>&1 || { printf >&2 "${RED}zcat command is required but it's not installed. ('brew install xz' on macOS, 'apt-get install xz-utils' on Debian/Ubuntu) Aborting.${RESET}\n"; exit 1; }
 # Check Docker is running
 if docker run --rm -t busybox:latest ls >/dev/null
 then

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -145,7 +145,7 @@ cd ${STAGING_DIR}
 
 echo "Creating sprint.tar.xz..."
 # Create tar.xz archive using xz command, so we can work on all platforms
-pushd sprint >/dev/null && tar -cvJf ../sprint.tar.xz . && popd >/dev/null
+pushd sprint >/dev/null && tar -cJf ../sprint.tar.xz . && popd >/dev/null
 rm -rf ${STAGING_DIR}/sprint
 
 cd ${STAGING_DIR_BASE}
@@ -163,4 +163,4 @@ printf "${GREEN}####
 # The built sprint tarballs and zipballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}.
 #
 # Package is built, staging directory remains in ${STAGING_DIR}.
-####${RESET}"
+####${RESET}\n"

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -24,22 +24,24 @@ printf "
 ${GREEN}
 ####
 # This script starts a Drupal 8 instance checked out from head
-# running in ddev with a fresh database.
+# running in ddev with a fresh database.${RESET}"
+if [ -d drupal8 ] ; then
+  printf "${GREEN}
 #
 # Make sure you've uploaded any patches from last issue
 # you worked on before continuing. This will revert all
 # local code and database changes.
 #
-####
-${RESET}"
-while true; do
-    read -p "Continue? (y/n): " INSTALL
-    case $INSTALL in
-        [Yy]* ) printf "${GREEN}# Continuing \n#### \n${RESET}"; break;;
-        [Nn]* ) exit;;
-        * ) echo "Please answer y or n.";;
-    esac
-done
+####${RESET}\n"
+    while true; do
+        read -p "Continue? (y/n): " INSTALL
+        case $INSTALL in
+            [Yy]* ) printf "${GREEN}# Continuing \n#### \n${RESET}"; break;;
+            [Nn]* ) exit;;
+            * ) echo "Please answer y or n.";;
+        esac
+    done
+fi
 
 echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which ddev)"
 

--- a/sprint/start_clean.sh
+++ b/sprint/start_clean.sh
@@ -24,24 +24,22 @@ printf "
 ${GREEN}
 ####
 # This script starts a Drupal 8 instance checked out from head
-# running in ddev with a fresh database.${RESET}"
-if [ -d drupal8 ] ; then
-  printf "${GREEN}
+# running in ddev with a fresh database.
 #
 # Make sure you've uploaded any patches from last issue
 # you worked on before continuing. This will revert all
 # local code and database changes.
 #
-####${RESET}\n"
-    while true; do
-        read -p "Continue? (y/n): " INSTALL
-        case $INSTALL in
-            [Yy]* ) printf "${GREEN}# Continuing \n#### \n${RESET}"; break;;
-            [Nn]* ) exit;;
-            * ) echo "Please answer y or n.";;
-        esac
-    done
-fi
+####
+${RESET}\n"
+while true; do
+    read -p "Continue? (y/n): " INSTALL
+    case $INSTALL in
+        [Yy]* ) printf "${GREEN}# Continuing \n#### \n${RESET}"; break;;
+        [Nn]* ) exit;;
+        * ) echo "Please answer y or n.";;
+    esac
+done
 
 echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which ddev)"
 

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -21,6 +21,7 @@ tar -xpf sprint.tar.xz -C ${SPRINTNAME}
 
 #Update ddev project name
 perl -pi -e "s/\[ts\]/${TIMESTAMP}/g" ${SPRINTNAME}/*.{txt,sh} ${SPRINTNAME}/.ddev/config.yaml
+rm -f ${SPRINTNAME}/*.bak
 
 # Next line is (only) stdout output, lets caller know the name of the project created
 printf ${SPRINTNAME}

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -31,7 +31,7 @@ function teardown {
 }
 
 @test "check git configuration" {
-    cd ${SPRINTDIR}/${SPRINT_NAME}
+    cd ${SPRINTDIR}/${SPRINT_NAME}/drupal8
     [ "$(git config core.eol)" = "lf" ]
     [ "$(git config core.autocrlf)" = "false" ]
     [ "$(git rev-parse --abbrev-ref HEAD)" = ${SPRINT_BRANCH} ]

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -5,6 +5,8 @@
 
 function setup {
     echo "# setup beginning" >&3
+    export SPRINT_BRANCH=8.7.x
+
     export SPRINTDIR=~/sprint
     # DRUD_NONINTERACTIVE causes ddev not to try to use sudo and add the hostname
     export DRUD_NONINTERACTIVE=true
@@ -26,6 +28,13 @@ function teardown {
         rm -rf ${SPRINTDIR}/${SPRINT_NAME}
     fi
     echo "# teardown complete" >&3
+}
+
+@test "check git configuration" {
+    cd ${SPRINTDIR}/${SPRINT_NAME}
+    [ "$(git config core.eol)" = "lf" ]
+    [ "${git config core.autocrlf" = "false" ]
+    [ "$(git rev-parse --abbrev-ref HEAD)" = ${SPRINT_BRANCH} ]
 }
 
 @test "check ddev project status and router status, check http status" {

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -33,7 +33,7 @@ function teardown {
 @test "check git configuration" {
     cd ${SPRINTDIR}/${SPRINT_NAME}
     [ "$(git config core.eol)" = "lf" ]
-    [ "${git config core.autocrlf" = "false" ]
+    [ "$(git config core.autocrlf") = "false" ]
     [ "$(git rev-parse --abbrev-ref HEAD)" = ${SPRINT_BRANCH} ]
 }
 

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -33,7 +33,7 @@ function teardown {
 @test "check git configuration" {
     cd ${SPRINTDIR}/${SPRINT_NAME}
     [ "$(git config core.eol)" = "lf" ]
-    [ "$(git config core.autocrlf") = "false" ]
+    [ "$(git config core.autocrlf)" = "false" ]
     [ "$(git rev-parse --abbrev-ref HEAD)" = ${SPRINT_BRANCH} ]
 }
 

--- a/tests/sanetestbot.sh
+++ b/tests/sanetestbot.sh
@@ -21,7 +21,11 @@ fi
 for item in curl jq zcat composer perl zip bats; do
     command -v $item >/dev/null || ( echo "$item is not installed" && exit 2 )
 done
-docker run --rm -t -v "/$PWD:/junk" busybox ls //junk >/dev/null || ( echo "docker is not running" && exit 3 )
+
+DOCKER_CMD="docker run --rm -t -v "/$PWD:/junk" busybox ls //junk "
+# Try the docker run command twice because of the really annoying mkdir /c: file exists bug
+# Apparently https://github.com/docker/for-win/issues/1560
+(sleep 1 && ( $DOCKER_CMD >/dev/null ) || (sleep 1 && $DOCKER_CMD >/dev/null )) || ( echo "docker is not running or can't do `$DOCKER_CMD`" && exit 3 )
 
 if command -v ddev >/dev/null && [ "$(ddev version -j | jq -r .raw.cli)" \< "${MIN_DDEV_VERSION}" ] ; then
   echo "ddev version in $(command -v ddev) is inadequate: $(ddev version -j | jq -r .raw.cli)"


### PR DESCRIPTION
Discussion in OP #83.

The clone here will just specify for the *drupal* checkout core.autocrlf=false and core.eol=lf, which are best for any normal situation. 

This patch does not change the user's global configuration.

Test:
After start_clean.sh, cd into the "drupal" directory and `git config core.autocrlf` (should be false) and `git config core.eol` (should be lf). Most important to test this on Windows, but it will be the same everywhere.