### PR TITLE
Uses find to remove old ddev_tarballs

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -64,9 +64,9 @@ mkdir -p ${ddev_tarballs}
 
 # Remove anything in staging directory except ddev_tarballs.
 rm -rf "${STAGING_DIR}/{*.md,install.sh,sprint,start_sprint.sh}"
-# Remove anytyhing in ddev_tarballs that is not the latest version
-if [ -d $ddev_tarballs ] && (ls $ddev_tarballs/* | grep -v ${LATEST_VERSION}) ; then
-    rm $(ls $ddev_tarballs/* | grep -v ${LATEST_VERSION})
+# Remove anything in ddev_tarballs that is not the latest version
+if [ -d "${ddev_tarballs}" ]; then
+     find "${ddev_tarballs}" -type f -not -name "*${LATEST_VERSION}*" -exec rm '{}' \;
 fi
 
 # Install the beginning items we need in the kit.


### PR DESCRIPTION
Follow-up from #102:

`ls: cannot access /home/circleci/tmp/drupal_sprint_package/ddev_tarballs/*: No such file or directory`

My solution was to rework as a find command. This is available in git-bash, but I haven't tested manually yet on linux or windows (theoretically the same with GNU find). I was lazy and didn't pipe to xargs since it should be a low number of files.