### PR TITLE
Fix chmod error output, fixes #110

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -65,6 +65,8 @@ ddev_tarballs="${STAGING_DIR}/ddev_tarballs"
 mkdir -p ${ddev_tarballs}
 
 # Remove anything in staging directory except ddev_tarballs.
+# Chmod as on WIndows read-only stuff is often unremoveable
+chmod -R u+w ${STAGING_DIR}/{*.md,install.sh,sprint,start_sprint.sh} || true
 rm -rf ${STAGING_DIR}/{*.md,install.sh,sprint,start_sprint.sh}
 # Remove anything in ddev_tarballs that is not the latest version
 if [ -d "${ddev_tarballs}" ]; then
@@ -146,6 +148,7 @@ cd ${STAGING_DIR}
 echo "Creating sprint.tar.xz..."
 # Create tar.xz archive using xz command, so we can work on all platforms
 pushd sprint >/dev/null && tar -cJf ../sprint.tar.xz . && popd >/dev/null
+if [ -f ${STAGING_DIR}/sprint} ] ; then chmod -R u+w ${STAGING_DIR}/sprint; fi
 rm -rf ${STAGING_DIR}/sprint
 
 cd ${STAGING_DIR_BASE}
@@ -154,6 +157,7 @@ if [ "$INSTALL" != "n" ] ; then
     tar -cf - ${STAGING_DIR_NAME} | gzip -9 >drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz
     zip -9 -r -q drupal_sprint_package.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
 fi
+if [ -f ${STAGING_DIR_NAME}/installs ]; then chmod -R u+w ${STAGING_DIR_NAME}/installs; fi
 rm -rf ${STAGING_DIR_NAME}/installs
 echo "Creating no-docker sprint package..."
 tar -cf - ${STAGING_DIR_NAME} | gzip -9 > drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -25,6 +25,7 @@ function teardown {
 
     ddev rm -R --omit-snapshot ${SPRINT_NAME}
     if [ ! -z "${SPRINTDIR}" -a ! -z "${SPRINT_NAME}" -a -d ${SPRINTDIR}/${SPRINT_NAME} ] ; then
+        chmod -R u+w ${SPRINTDIR}/${SPRINT_NAME}
         rm -rf ${SPRINTDIR}/${SPRINT_NAME}
     fi
     echo "# teardown complete" >&3

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -28,7 +28,7 @@ trap cleanup EXIT
 
 
 # Clean up any previous existing stuff
-(chmod -R ugo+w "$SPRINTDIR/" && rm -rf  ${SPRINTDIR}/sprint-2* ) || true
+(mkdir -p ${SPRINTDIR} && chmod -R ugo+w "$SPRINTDIR/" && rm -rf  ${SPRINTDIR}/sprint-2* ) || true
 rm -rf "$UNTARRED_PACKAGE"
 
 echo n | ./package_drupal_script.sh || ( echo "package_drupal_script.sh failed" && exit 2 )


### PR DESCRIPTION
This should fix the chmod error output in OP #110 

I took the liberty of fixing another piece of output I saw in test logs, about rm failing on windows; On windows it refuses to rm -r a directory with 444 files in it.