### PR TITLE
Error: Accidental commit of ugly debugging code

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,9 +48,9 @@ printf "Installing docker images for ddev to use...\n"
 # Allow faster turnaround on testing by export QUICKSPRINT_SKIP_IMAGE_INSTALL=true
 if [ -z "${QUICKSPRINT_SKIP_IMAGE_INSTALL:-}" ]; then
     if command -v xzcat >/dev/null; then
-        true # xzcat ddev_tarballs/ddev_docker_images*.tar.xz | docker load
+        xzcat ddev_tarballs/ddev_docker_images*.tar.xz | docker load
     elif [[ "$OS" == "Darwin" ]]; then
-        true #gzip -dc ddev_tarballs/ddev_docker_images*.tar.xz | docker load
+        gzip -dc ddev_tarballs/ddev_docker_images*.tar.xz | docker load
     else
         printf "${YELLOW}Unable to load ddev_docker_images. They will load at first 'ddev start'.${RESET}\n"
     fi


### PR DESCRIPTION
I accidentally committed debugging code which prevented install.sh from ever installing the docker images. Ooops. This removes that debugging code. Ironically, I explicitly added an environment variable to control that behavior for testing, so didn't need to have done that in the first place.