### PR TITLE
tag_build should build all packages including with installers

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -12,4 +12,4 @@ echo "n" | ./package_drupal_script.sh
 echo "--- test_drupal_quicksprint.sh"
 tests/test_drupal_quicksprint.sh
 echo "--- cleanup"
-rm -f ~/tmp/drupal_sprint_package.no_docker.$(cat .quicksprint_release.txt).tar.gz
+rm -f ~/tmp/drupal_sprint_package.no_extra_installs.*$(cat .quicksprint_release.txt)*.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
         name: NORMAL Circle VM setup - tools, docker
     - run:
         command: |
-          sudo mkdir $ARTIFACTS && sudo chmod ugo+w $ARTIFACTS && cp ~/tmp/drupal_sprint_package.$(cat .quicksprint_release.txt).{tar.gz,zip}  $ARTIFACTS
+          sudo mkdir $ARTIFACTS && sudo chmod ugo+w $ARTIFACTS && cp ~/tmp/drupal_sprint_package.*$(cat .quicksprint_release.txt)*.{tar.gz,zip}  $ARTIFACTS
           cd $ARTIFACTS
           for item in *.tar.gz *.zip; do
             sha256sum $item > $item.sha256.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
         command: ./.circleci/circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker
     - run:
-        command: echo "y" | time ./package_drupal_script.sh
+        command: echo "y" | ./package_drupal_script.sh
         name: Run the package_drupal_script.sh
         no_output_timeout: "20m"
     - persist_to_workspace:

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -159,9 +159,9 @@ if [ "$INSTALL" != "n" ] ; then
 fi
 if [ -f ${STAGING_DIR_NAME}/installs ]; then chmod -R u+w ${STAGING_DIR_NAME}/installs; fi
 rm -rf ${STAGING_DIR_NAME}/installs
-echo "Creating no-docker sprint package..."
-tar -cf - ${STAGING_DIR_NAME} | gzip -9 > drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
-zip -9 -r -q drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
+echo "Creating no_extra_installs sprint package..."
+tar -cf - ${STAGING_DIR_NAME} | gzip -9 > drupal_sprint_package.no_extra_installs.${QUICKSPRINT_RELEASE}.tar.gz
+zip -9 -r -q drupal_sprint_package.no_extra_installs.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
 
 packages=$(ls ${STAGING_DIR_BASE}/drupal_sprint_package*${QUICKSPRINT_RELEASE}*)
 printf "${GREEN}####

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -163,8 +163,10 @@ echo "Creating no-docker sprint package..."
 tar -cf - ${STAGING_DIR_NAME} | gzip -9 > drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
 zip -9 -r -q drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
 
+packages=$(ls ${STAGING_DIR_BASE}/drupal_sprint_package*${QUICKSPRINT_RELEASE}*)
 printf "${GREEN}####
-# The built sprint tarballs and zipballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}.
+# The built sprint tarballs and zipballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}:
+# ${packages:-}
 #
 # Package is built, staging directory remains in ${STAGING_DIR}.
 ####${RESET}\n"

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -33,7 +33,7 @@ rm -rf "$UNTARRED_PACKAGE"
 
 echo n | ./package_drupal_script.sh || ( echo "package_drupal_script.sh failed" && exit 2 )
 # SOURCE_TARBALL_LOCATION isn't valid until package_drupal_script has run.
-SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_docker.${QUICKSPRINT_RELEASE}.tar.gz
+SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_extra_installs.${QUICKSPRINT_RELEASE}.tar.gz
 
 # Untar source tarball
 tar -C "$UNTAR_LOCATION" -zxf ${SOURCE_TARBALL_LOCATION:-}


### PR DESCRIPTION
I noticed in recent tag builds that we weren't building the tarballs that included installs. This was apparently some odd side-effect of having added "time" in front of package_build.sh for debugging information.

While there, I added an environment variable to control this, so we won't build the monster tarballs with installs except on tag build.