### PR TITLE
ddev should not hide output, and should prompt for sudo prompt, fixes #123

### DIFF
--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -36,9 +36,10 @@ echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which 
 
 ddev config --docroot drupal8 --project-type drupal8 --php-version=7.2 --http-port=8080 --https-port=8443 --project-name="sprint-${TIMESTAMP}"
 
+ddev config global --instrumentation-opt-in=false >/dev/null
 printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}\n"
-printf "${YELLOW}Running ddev start...${RESET}\n"
-ddev start >ddev_start.txt 2>&1 || (echo "ddev start failed: $(cat ddev_start.txt)" && exit 101)
+printf "${YELLOW}Running ddev start...YOU MAY BE ASKED for your sudo password to add a hostname to /etc/hosts${RESET}\n"
+ddev start || (printf "${RED}ddev start failed.${RESET}" && exit 101)
 printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}...\n"
 ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'" || (echo "ddev exec bash...git reset failed" && exit 102)
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -31,10 +31,10 @@ else
     exit 1
 fi
 
-cd "${SPRINTNAME}"
+cd "${SPRINTNAME}/drupal8"
 echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which ddev)"
 
-ddev config --docroot drupal8 --project-type drupal8 --php-version=7.2 --http-port=8080 --https-port=8443 --project-name="sprint-${TIMESTAMP}"
+ddev config --docroot . --project-type drupal8 --php-version=7.2 --http-port=8080 --https-port=8443 --project-name="sprint-${TIMESTAMP}"
 
 ddev config global --instrumentation-opt-in=false >/dev/null
 printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}\n"
@@ -43,7 +43,7 @@ ddev start || (printf "${RED}ddev start failed.${RESET}" && exit 101)
 printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}...\n"
 ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'" || (echo "ddev exec bash...git reset failed" && exit 102)
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
-ddev composer install -d drupal8
+ddev composer install
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
 ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting"
 printf "${RESET}"

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -38,7 +38,7 @@ function teardown {
 }
 
 @test "check ddev project status and router status, check http status" {
-    cd ${SPRINTDIR}/${SPRINT_NAME}
+    cd ${SPRINTDIR}/${SPRINT_NAME}/drupal8
     DESCRIBE=$(ddev describe -j)
 
     ROUTER_STATUS=$(echo "${DESCRIBE}" | jq -r ".raw.router_status" )


### PR DESCRIPTION
#123 pointed out that on a clean machine that's never run ddev before, a couple of things can happen:

* the sudo prompt may not be obvious (for adding the project hostname to /etc/hosts)
* The prompt to opt in to ddev instrumentation may be hidden

This PR 
* removes the hiding of `ddev start` output that had been added, to make the sudo request more obvious.
* Does a pre-emptive `ddev config global --instrumentation-opt-in=false` to make sure people don't have to even answer the opt-in question that's there if ~/.ddev/global_config.yaml does not exist.
* Adds a little extra prompting about when that sudo might occur.

For manual testing you really only have to test start_sprint.sh, but:
1. Make sure you `rm -rf ~/.ddev`
2. Sudo should be set to always request a password. I added `Defaults        env_reset,timestamp_timeout=0` and changed `%admin         ALL = NOPASSWD: ALL` on my `visudo` to `%admin         ALL = (ALL) ALL`
3. Make sure you remove existing hostnames. You can do this with `ddev rm -a && sudo ddev hostname --remove-inactive`. 