### PR TITLE
Tell people to open a new window before running start_sprint.sh, fixes #125

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,10 @@ ${GREEN}
 ######
 #
 # Your ddev and the sprint kit are now ready to use,
-# execute the following commands now to start:
+# Please open a NEW WINDOW to make sure you have any additional PATHs
+# and execute the following commands to start:
+#
+# IN A NEW WINDOW:
 #
 # ${YELLOW}cd ~/sprint${GREEN}
 # ${YELLOW}./start_sprint.sh${GREEN}


### PR DESCRIPTION
In #125 @andrewfrench points out that users who have never before installed ddev may very well not have the ddev executables in the path in the current window. Opening a new window should solve that, so this PR just edits the instructions at the end of install.sh asking people to open a new window.

The reality is this only matters with the Windows installs.