### PR TITLE
Fix nightly: Attempt to fix bash -c problem with ddev exec

### DIFF
--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -45,7 +45,7 @@ ddev exec "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'" || (echo "dd
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
 ddev composer install
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
-ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Sprinting'
+ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Sprinting'
 printf "${RESET}"
 ddev describe
 

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -41,11 +41,11 @@ printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minut
 printf "${YELLOW}Running ddev start...YOU MAY BE ASKED for your sudo password to add a hostname to /etc/hosts${RESET}\n"
 ddev start || (printf "${RED}ddev start failed.${RESET}" && exit 101)
 printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}...\n"
-ddev exec bash -c "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'" || (echo "ddev exec bash...git reset failed" && exit 102)
+ddev exec "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'" || (echo "ddev exec...git reset failed" && exit 102)
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
 ddev composer install
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
-ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name="Drupal Sprinting"
+ddev exec drush si standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Sprinting'
 printf "${RESET}"
 ddev describe
 

--- a/tests/sanetestbot.sh
+++ b/tests/sanetestbot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MIN_DDEV_VERSION=v1.5
+MIN_DDEV_VERSION=v1.8
 
 set -o errexit
 set -o pipefail
@@ -27,7 +27,7 @@ DOCKER_CMD="docker run --rm -t -v "/$PWD:/junk" busybox ls //junk "
 # Apparently https://github.com/docker/for-win/issues/1560
 (sleep 1 && ( $DOCKER_CMD >/dev/null ) || (sleep 1 && $DOCKER_CMD >/dev/null )) || ( echo "docker is not running or can't do `$DOCKER_CMD`" && exit 3 )
 
-if command -v ddev >/dev/null && [ "$(ddev version -j | jq -r .raw.cli)" \< "${MIN_DDEV_VERSION}" ] ; then
+if command -v ddev >/dev/null && [ "$(ddev version -j | jq -r .raw.commit)" \< "${MIN_DDEV_VERSION}" ] ; then
   echo "ddev version in $(command -v ddev) is inadequate: $(ddev version -j | jq -r .raw.cli)"
   exit 4
 fi


### PR DESCRIPTION
The nightly build has been broken after release of ddev v1.8.0; `ddev exec` now no longer needs a "bash -c" to execute bash stuff.