### PR TITLE
Split installs into its own tarball, fixes #134

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -12,7 +12,7 @@ echo "--- running testbot_maintenance.sh"
 bash $(dirname $0)/testbot_maintenance.sh
 
 echo "--- package_drupal_script.sh"
-rm -f ~/tmp/drupal_sprint_package*gz ~/tmp/drupal_sprint_package*zip
+rm -f ~/tmp/quicksprint_thirdparty*gz ~/tmp/drupal_sprint_package*gz ~/tmp/drupal_sprint_package*zip
 echo "n" | ./package_drupal_script.sh
 echo "--- test_drupal_quicksprint.sh"
 tests/test_drupal_quicksprint.sh

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -95,7 +95,7 @@ ${GREEN}
 #### \n${RESET}"
 
 while true; do
-    read -p "Include installers? (y/n): " INSTALL
+    read -p "Create installer tarball? (y/n): " INSTALL
     case ${INSTALL} in
         [Yy]* ) printf "${GREEN}# Downloading installers. \n#### \n${RESET}";
                 mkdir -p installs
@@ -153,19 +153,19 @@ rm -rf ${STAGING_DIR}/sprint
 
 cd ${STAGING_DIR_BASE}
 if [ "$INSTALL" != "n" ] ; then
-    echo "Creating drupal_sprint_package with installs..."
-    tar -cf - ${STAGING_DIR_NAME} | gzip -9 >drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz
-    zip -9 -r -q drupal_sprint_package.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
+    echo "Creating install tarball..."
+    tar -cf - ${STAGING_DIR_NAME}/installs | gzip -9 >quicksprint_thirdpart_installs.${QUICKSPRINT_RELEASE}.tar.gz
+    zip -9 -r -q quicksprint_thirdpart_installs.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}/installs
 fi
 if [ -f ${STAGING_DIR_NAME}/installs ]; then chmod -R u+w ${STAGING_DIR_NAME}/installs; fi
 rm -rf ${STAGING_DIR_NAME}/installs
-echo "Creating no_extra_installs sprint package..."
-tar -cf - ${STAGING_DIR_NAME} | gzip -9 > drupal_sprint_package.no_extra_installs.${QUICKSPRINT_RELEASE}.tar.gz
-zip -9 -r -q drupal_sprint_package.no_extra_installs.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
+echo "Creating sprint package..."
+tar -cf - ${STAGING_DIR_NAME} | gzip -9 > drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz
+zip -9 -r -q drupal_sprint_package.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}
 
 packages=$(ls ${STAGING_DIR_BASE}/drupal_sprint_package*${QUICKSPRINT_RELEASE}*)
 printf "${GREEN}####
-# The built tarballs and zipballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}:
+# The built sprint tarballs and optional install tarballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}:
 # ${packages:-}
 #
 # Package is built, staging directory remains in ${STAGING_DIR}.

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -154,8 +154,8 @@ rm -rf ${STAGING_DIR}/sprint
 cd ${STAGING_DIR_BASE}
 if [ "$INSTALL" != "n" ] ; then
     echo "Creating install tarball..."
-    tar -cf - ${STAGING_DIR_NAME}/installs | gzip -9 >quicksprint_thirdpart_installs.${QUICKSPRINT_RELEASE}.tar.gz
-    zip -9 -r -q quicksprint_thirdpart_installs.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}/installs
+    tar -cf - ${STAGING_DIR_NAME}/installs | gzip -9 >quicksprint_thirdparty_installs.${QUICKSPRINT_RELEASE}.tar.gz
+    zip -9 -r -q quicksprint_thirdparty_installs.${QUICKSPRINT_RELEASE}.zip ${STAGING_DIR_NAME}/installs
 fi
 if [ -f ${STAGING_DIR_NAME}/installs ]; then chmod -R u+w ${STAGING_DIR_NAME}/installs; fi
 rm -rf ${STAGING_DIR_NAME}/installs

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -33,7 +33,7 @@ rm -rf "$UNTARRED_PACKAGE"
 
 echo n | ./package_drupal_script.sh || ( echo "package_drupal_script.sh failed" && exit 2 )
 # SOURCE_TARBALL_LOCATION isn't valid until package_drupal_script has run.
-SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_extra_installs.${QUICKSPRINT_RELEASE}.tar.gz
+SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.${QUICKSPRINT_RELEASE}.tar.gz
 
 # Untar source tarball
 tar -C "$UNTAR_LOCATION" -zxf ${SOURCE_TARBALL_LOCATION:-}


### PR DESCRIPTION
This splits the tarball into the sprint stuff and the installs.