### PR TITLE
Change site URL from ddev.local to ddev.site, fixes #133

### DIFF
--- a/DRUPAL_MAINTAINER_README.md
+++ b/DRUPAL_MAINTAINER_README.md
@@ -53,4 +53,4 @@ There are some better tools to automate USB flash drive imaging, but your mileag
 * Run install.sh from the unarchived directory; (Windows users must work in git-bash).
 * After installation, users can start up an instance by cd-ing to ~/sprint and running ./start_sprint.sh. 
 
-At this point the plain vanilla git-checked-out drupal8 HEAD version should be running at http://drupal8.ddev.local.
+At this point the plain vanilla git-checked-out drupal8 HEAD version should be running at http://drupal8.ddev.site.

--- a/sprint/Readme.txt
+++ b/sprint/Readme.txt
@@ -1,10 +1,10 @@
 To access
-Website:     http://sprint-[ts].ddev.local:8080/
-             https://sprint-[ts].ddev.local:8443/
+Website:     http://sprint-[ts].ddev.site:8080/
+             https://sprint-[ts].ddev.site:8443/
              (User:admin Pass:admin)
 
-Mailhog:     http://sprint-[ts].ddev.local:8025/
-phpMyAdmin:  http://sprint-[ts].ddev.local:8036/
+Mailhog:     http://sprint-[ts].ddev.site:8025/
+phpMyAdmin:  http://sprint-[ts].ddev.site:8036/
 Chat:        https://drupal.org/chat to join Drupal Slack or drupalchat.eu!
 
 

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -54,13 +54,13 @@ ${GREEN}
 ####
 # Use the following URL's to access your site:
 #
-# Website:    ${YELLOW}http://sprint-${TIMESTAMP}.ddev.local:8080/${GREEN}
-#             ${YELLOW}https://sprint-${TIMESTAMP}.ddev.local:8443/${GREEN}
+# Website:    ${YELLOW}http://sprint-${TIMESTAMP}.ddev.site:8080/${GREEN}
+#             ${YELLOW}https://sprint-${TIMESTAMP}.ddev.site:8443/${GREEN}
 #             ${YELLOW}(U:admin  P:admin)${GREEN}
 #
-# ${GREEN}Mailhog:    ${YELLOW}http://sprint-${TIMESTAMP}.ddev.local:8025/${GREEN}
+# ${GREEN}Mailhog:    ${YELLOW}http://sprint-${TIMESTAMP}.ddev.site:8025/${GREEN}
 #
-# phpMyAdmin: ${YELLOW}http://sprint-${TIMESTAMP}.ddev.local:8036/${GREEN}
+# phpMyAdmin: ${YELLOW}http://sprint-${TIMESTAMP}.ddev.site:8036/${GREEN}
 #
 # Chat:       ${YELLOW}https://drupal.org/chat to join Drupal Slack or https://drupalchat.me${GREEN}
 #

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -58,7 +58,7 @@ function teardown {
     NAME=$(echo ${DESCRIBE} | jq -r ".raw.name")
     HTTP_PORT=$(echo ${DESCRIBE} | jq -r ".raw.router_http_port")
     URL="http://${DHOST}:${HTTP_PORT}"
-    CURL="curl --fail -H 'Host: ${NAME}.ddev.local' --silent --output /dev/null --url $URL"
+    CURL="curl --fail -H 'Host: ${NAME}.ddev.site' --silent --output /dev/null --url $URL"
     echo "# curl: $CURL" >&3
     ${CURL}
 }


### PR DESCRIPTION
ddev's default FQDN changed from "ddev.local" to "ddev.site" a few versions ago, docs here need to reflect that.