### PR TITLE
Add release publishing, fixes #119

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.0
 
 jobs:
-
   "package_build":
     machine:
       image: ubuntu-1604:201903-01
@@ -44,7 +43,7 @@ jobs:
       image: ubuntu-1604:201903-01
     working_directory: ~/quicksprint
     environment:
-      ARTIFACTS: /artifacts
+      ARTIFACTS: ~/artifacts
       DDEV_NO_INSTRUMENTATION: true
     steps:
     - attach_workspace:
@@ -62,7 +61,7 @@ jobs:
         name: make artifacts tarball downloads
         no_output_timeout: "20m"
     - store_artifacts:
-        path: /artifacts
+        path: $ARTIFACTS
         name: Artifact storage
 
   publish-github-release:
@@ -70,11 +69,11 @@ jobs:
     - image: cibuilds/github:0.10
     steps:
     - attach_workspace:
-        at: ./artifacts
+        at: ~/
     - run:
         name: "Publish Release on GitHub"
         command: |
-          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} /artifacts/
+          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} $ARTIFACTS
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,7 @@ jobs:
     - run:
         name: "Publish Release on GitHub"
         command: |
-          VERSION=$(git describe --tags)
-          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} /artifacts/
+          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} /artifacts/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,12 @@ jobs:
     - store_artifacts:
         path: $ARTIFACTS
         name: Artifact storage
+    - persist_to_workspace:
+        root: ~/
+        paths:
+        - quicksprint
+        - tmp
+        - artifacts
 
   publish-github-release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,19 @@ jobs:
     - store_artifacts:
         path: /artifacts
         name: Artifact storage
-        
+
+  publish-github-release:
+    docker:
+    - image: cibuilds/github:0.10
+    steps:
+    - attach_workspace:
+        at: ./artifacts
+    - run:
+        name: "Publish Release on GitHub"
+        command: |
+          VERSION=$(my-binary --version)
+          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} /artifacts/
+
 workflows:
   version: 2
   normal_build_and_test:
@@ -116,6 +128,16 @@ workflows:
     - artifacts:
         requires:
         - package_build
+        filters:
+          tags:
+            only:
+            - "/.*/"
+          branches:
+            ignore: /.*/
+    - publish-github-release:
+        requires:
+        - artifacts
+        - test_package
         filters:
           tags:
             only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,7 @@ jobs:
         name: NORMAL Circle VM setup - tools, docker
     - run:
         command: |
-          sudo mkdir $ARTIFACTS && sudo chmod ugo+w $ARTIFACTS && cp ~/tmp/*$(cat .quicksprint_release.txt)*.{tar.gz,zip}  $ARTIFACTS
-          cd $ARTIFACTS
+          mkdir $ARTIFACTS && cd $ARTIFACTS && cp ~/tmp/*$(cat .quicksprint_release.txt)*.{tar.gz,zip} .
           for item in *.tar.gz *.zip; do
             sha256sum $item > $item.sha256.txt
           done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,14 +53,14 @@ jobs:
         name: NORMAL Circle VM setup - tools, docker
     - run:
         command: |
-          mkdir $ARTIFACTS && cd $ARTIFACTS && cp ~/tmp/*$(cat .quicksprint_release.txt)*.{tar.gz,zip} .
+          mkdir /home/circleci/artifacts && cd /home/circleci/artifacts && cp ~/tmp/*$(cat .quicksprint_release.txt)*.{tar.gz,zip} .
           for item in *.tar.gz *.zip; do
             sha256sum $item > $item.sha256.txt
           done
         name: make artifacts tarball downloads
         no_output_timeout: "20m"
     - store_artifacts:
-        path: $ARTIFACTS
+        path: /home/circleci/artifacts
         name: Artifact storage
     - persist_to_workspace:
         root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       image: ubuntu-1604:201903-01
     working_directory: ~/quicksprint
     environment:
-      ARTIFACTS: ~/artifacts
+      ARTIFACTS: /home/circleci/artifacts
       DDEV_NO_INSTRUMENTATION: true
     steps:
     - attach_workspace:
@@ -70,6 +70,8 @@ jobs:
         - artifacts
 
   publish-github-release:
+    environment:
+      ARTIFACTS: /root/artifacts
     docker:
     - image: cibuilds/github:0.10
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     - run:
         name: "Publish Release on GitHub"
         command: |
-          VERSION=$(my-binary --version)
+          VERSION=$(git describe --tags)
           ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} /artifacts/
 
 workflows:

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -41,7 +41,7 @@ printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minut
 printf "${YELLOW}Running ddev start...YOU MAY BE ASKED for your sudo password to add a hostname to /etc/hosts${RESET}\n"
 ddev start || (printf "${RED}ddev start failed.${RESET}" && exit 101)
 printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}...\n"
-ddev exec "git fetch && git reset --hard 'origin/${SPRINT_BRANCH}'" || (echo "ddev exec...git reset failed" && exit 102)
+ddev exec "(git fetch && git reset --hard 'origin/${SPRINT_BRANCH}') || (echo "ddev exec...git reset failed" && exit 102)
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
 ddev composer install
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -41,11 +41,11 @@ printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minut
 printf "${YELLOW}Running ddev start...YOU MAY BE ASKED for your sudo password to add a hostname to /etc/hosts${RESET}\n"
 ddev start || (printf "${RED}ddev start failed.${RESET}" && exit 101)
 printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}...\n"
-ddev exec "(git fetch && git reset --hard 'origin/${SPRINT_BRANCH}') || (echo "ddev exec...git reset failed" && exit 102)
+ddev exec "(git fetch && git reset --hard 'origin/${SPRINT_BRANCH}') || (echo 'ddev exec...git reset failed' && exit 102)"
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
 ddev composer install
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
-ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Sprinting'
+ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
 printf "${RESET}"
 ddev describe
 


### PR DESCRIPTION
OP #119 suggests automatically publishing the release.

This adds publishing on tag build only, and doesn't work on forked repos, so there shouldn't be security concerns.