### PR TITLE
Testing updates for Quicksprint, tests only

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -16,4 +16,4 @@ echo "n" | ./package_drupal_script.sh
 echo "--- test_drupal_quicksprint.sh"
 tests/test_drupal_quicksprint.sh
 echo "--- cleanup"
-rm -f ~/tmp/drupal_sprint_package.no_extra_installs.*$(cat .quicksprint_release.txt)*.tar.gz
+rm -f ~/tmp/*$(cat .quicksprint_release.txt)*.tar.gz

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -5,6 +5,7 @@ echo "--- buildkite building at $(date) on $(hostname) for OS=$(go env GOOS) in 
 set -o errexit
 set -o pipefail
 set -o nounset
+export DDEV_NO_INSTRUMENTATION=true
 
 # Run any testbot maintenance that may need to be done
 echo "--- running testbot_maintenance.sh"

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "--- buildkite building at $(date) on $(hostname) for OS=$(go env GOOS) in $PWD with golang=$(go version) docker=$(docker version --format '{{.Server.Version}}') and docker-compose $(docker-compose version --short) ddev version=$(ddev version -j | jq -r .raw.cli)"
+echo "--- buildkite building at $(date) on $(hostname) for OS=$(go env GOOS) in $PWD with golang=$(go version) docker=$(docker version --format '{{.Server.Version}}') and docker-compose $(docker-compose version --short) ddev version=$(ddev --version)"
 
 set -o errexit
 set -o pipefail

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -6,6 +6,10 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+# Run any testbot maintenance that may need to be done
+echo "--- running testbot_maintenance.sh"
+bash $(dirname $0)/testbot_maintenance.sh
+
 echo "--- package_drupal_script.sh"
 rm -f ~/tmp/drupal_sprint_package*gz ~/tmp/drupal_sprint_package*zip
 echo "n" | ./package_drupal_script.sh

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -8,10 +8,12 @@ os=$(go env GOOS)
 case $os in
 darwin)
     brew upgrade mkcert || brew install mkcert || true
+    brew upgrade composer || brew install composer || true
     rm /usr/local/bin/ddev && brew unlink ddev && (brew upgrade ddev || brew install ddev || true)
     brew link ddev
+
     ;;
 windows)
-    choco upgrade -y mkcert ddev
+    choco upgrade -y mkcert ddev composer
     ;;
 esac

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eu
+
+os=$(go env GOOS)
+
+# Upgrade darwin and windows packages
+case $os in
+darwin)
+    brew upgrade mkcert || brew install mkcert || true
+    brew unlink ddev && (brew upgrade ddev || brew install ddev || true)
+    brew link ddev
+    ;;
+windows)
+    choco upgrade -y mkcert ddev
+    ;;
+esac

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -8,7 +8,7 @@ os=$(go env GOOS)
 case $os in
 darwin)
     brew upgrade mkcert || brew install mkcert || true
-    brew unlink ddev && (brew upgrade ddev || brew install ddev || true)
+    rm /usr/local/bin/ddev && brew unlink ddev && (brew upgrade ddev || brew install ddev || true)
     brew link ddev
     ;;
 windows)

--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -25,14 +25,18 @@ sudo add-apt-repository \
 sudo apt-get update -qq
 sudo apt-get install -qq docker-ce
 
-# docker-compose
-sudo rm -f /usr/local/bin/docker-compose
-sudo curl -s -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
+if [ ! -d /home/linuxbrew/.linuxbrew/bin ] ; then
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+fi
 
+echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 
-curl -sS https://getcomposer.org/installer -o composer-setup.php
-    sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+. ~/.bashrc
+
+brew update && brew tap drud/ddev
+for item in mkcert ddev docker-compose; do
+    brew install $item || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item
+done
 
 # install recent bats bash testing framework
 BATS_TAG=v1.1.0

--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -34,7 +34,7 @@ echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 . ~/.bashrc
 
 brew update && brew tap drud/ddev
-for item in mkcert ddev docker-compose; do
+for item in mkcert ddev composer php docker-compose; do
     brew install $item || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item
 done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,14 @@ jobs:
     working_directory: ~/quicksprint
     environment:
       TERM: vt100
+      DDEV_NO_INSTRUMENTATION: true
     steps:
     - checkout
     - run:
         command: ./.circleci/circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker
     - run:
-        command: echo "y" | ./package_drupal_script.sh
+        command: source ~/.bashrc && echo "y" | ./package_drupal_script.sh
         name: Run the package_drupal_script.sh
         no_output_timeout: "20m"
     - persist_to_workspace:
@@ -28,13 +29,14 @@ jobs:
     working_directory: ~/quicksprint
     environment:
       TERM: vt100
+      DDEV_NO_INSTRUMENTATION: true
     steps:
     - attach_workspace:
         at: ~/
     - run:
         command: ./.circleci/circle_vm_setup.sh
         name: NORMAL Circle VM setup - tools, docker
-    - run: tests/test_drupal_quicksprint.sh
+    - run: source ~/.bashrc && tests/test_drupal_quicksprint.sh
 
 
   "artifacts":
@@ -43,6 +45,7 @@ jobs:
     working_directory: ~/quicksprint
     environment:
       ARTIFACTS: /artifacts
+      DDEV_NO_INSTRUMENTATION: true
     steps:
     - attach_workspace:
         at: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
         name: NORMAL Circle VM setup - tools, docker
     - run:
         command: |
-          sudo mkdir $ARTIFACTS && sudo chmod ugo+w $ARTIFACTS && cp ~/tmp/drupal_sprint_package.*$(cat .quicksprint_release.txt)*.{tar.gz,zip}  $ARTIFACTS
+          sudo mkdir $ARTIFACTS && sudo chmod ugo+w $ARTIFACTS && cp ~/tmp/*$(cat .quicksprint_release.txt)*.{tar.gz,zip}  $ARTIFACTS
           cd $ARTIFACTS
           for item in *.tar.gz *.zip; do
             sha256sum $item > $item.sha256.txt

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -135,8 +135,8 @@ git clone --config core.autocrlf=false --config core.eol=lf --quiet https://git.
 pushd ${STAGING_DIR}/sprint/drupal8 >/dev/null
 cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 
-echo "Running composer install --quiet"
-composer install --quiet
+echo "Running ddev composer install --quiet"
+ddev config --php-version=7.3 --project-type=drupal8 && ddev composer install --quiet
 popd >/dev/null
 
 # Copy licenses and COPYING notice.

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -138,7 +138,9 @@ cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 echo "Running ddev composer install --quiet"
 set -x
 ddev config --project-type=drupal8
+ddev start
 ddev composer install --quiet
+ddev poweroff
 set +x
 popd >/dev/null
 

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -135,13 +135,8 @@ git clone --config core.autocrlf=false --config core.eol=lf --quiet https://git.
 pushd ${STAGING_DIR}/sprint/drupal8 >/dev/null
 cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 
-echo "Running ddev composer install --quiet"
-set -x
-ddev config --project-type=drupal8
-ddev start
-ddev composer install --quiet
-ddev poweroff
-set +x
+echo "Running composer install --quiet"
+composer install --quiet
 popd >/dev/null
 
 # Copy licenses and COPYING notice.

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -136,7 +136,10 @@ pushd ${STAGING_DIR}/sprint/drupal8 >/dev/null
 cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 
 echo "Running ddev composer install --quiet"
-ddev config --php-version=7.3 --project-type=drupal8 && ddev composer install --quiet
+set -x
+ddev config --project-type=drupal8
+ddev composer install --quiet
+set +x
 popd >/dev/null
 
 # Copy licenses and COPYING notice.

--- a/tests/sanetestbot.sh
+++ b/tests/sanetestbot.sh
@@ -35,7 +35,7 @@ docker pull busybox:latest >/dev/null
 (sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null ))
 
 # Check that required commands are available.
-for command in curl jq zcat composer perl zip bats; do
+for command in curl jq zcat perl zip bats; do
     command -v $command >/dev/null || ( echo "Did not find command installed '$command'" && exit 2 )
 done
 

--- a/tests/sanetestbot.sh
+++ b/tests/sanetestbot.sh
@@ -35,7 +35,7 @@ docker pull busybox:latest >/dev/null
 (sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null ))
 
 # Check that required commands are available.
-for command in curl jq zcat perl zip bats; do
+for command in curl jq zcat perl zip bats composer php; do
     command -v $command >/dev/null || ( echo "Did not find command installed '$command'" && exit 2 )
 done
 

--- a/tests/sanetestbot.sh
+++ b/tests/sanetestbot.sh
@@ -3,7 +3,7 @@
 # Check a testbot or test environment to make sure it's likely to be sane.
 # We should add to this script whenever a testbot fails and we can figure out why.
 
-MIN_DDEV_VERSION=v1.8
+MIN_DDEV_VERSION=v1.11.0
 
 set -o errexit
 set -o pipefail
@@ -44,10 +44,9 @@ if [ "$(go env GOOS)" = "windows"  -a "$(git config core.autocrlf)" != "false" ]
  exit 3
 fi
 
-CURRENT_DDEV_VERSION=$(ddev --version  | awk '{ gsub(/^v/, "", $3); sub(/-.*$/, "", $3); print $3}' )
 CURRENT_DDEV_VERSION=$(ddev --version | awk '{ print $3 }')
-if command -v ddev >/dev/null && version_gt ${MIN_DDEV_VERSION} ${CURRENT_DDEV_VERSION} ; then
-  echo "ddev version in $(command -v ddev) is inadequate: $(ddev version -j | jq -r .raw.commit)"
+if version_gt ${MIN_DDEV_VERSION} ${CURRENT_DDEV_VERSION} ; then
+  echo "ddev version in $(command -v ddev) is inadequate: $(ddev --version)"
   exit 4
 fi
 

--- a/tests/sanetestbot.sh
+++ b/tests/sanetestbot.sh
@@ -1,35 +1,54 @@
 #!/bin/bash
 
+# Check a testbot or test environment to make sure it's likely to be sane.
+# We should add to this script whenever a testbot fails and we can figure out why.
+
 MIN_DDEV_VERSION=v1.8
 
 set -o errexit
 set -o pipefail
 set -o nounset
 
-echo "sanetestbot.sh: Check to see if test machine has what it needs"
-
-# brew install jq xz bats-core composer
-# choco install -y jq composer zip (gd and curl must be enabled in /c/tools/php72/php.ini)
- # git clone git://github.com/bats-core/bats-core; cd bats-core; git checkout v1.1.0; sudo ./install.sh /usr/local
+# thanks to https://stackoverflow.com/a/24067243/215713
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
 
 DISK_AVAIL=$(df -k . | awk '/[0-9]%/ { gsub(/%/, ""); print $5}')
 if [ ${DISK_AVAIL} -ge 95 ] ; then
     echo "Disk usage is ${DISK_AVAIL}% on $(hostname), not usable";
     exit 1;
+else
+   echo "Disk usage is ${DISK_AVAIL}% on $(hostname).";
 fi
 
-for item in curl jq zcat composer perl zip bats; do
-    command -v $item >/dev/null || ( echo "$item is not installed" && exit 2 )
+# Test to make sure docker is installed and working.
+# If it doesn't become ready then we just keep this testbot occupied :)
+docker ps >/dev/null
+while ! docker ps >/dev/null 2>&1 ; do
+    echo "Waiting for docker to be ready $(date)"
+    sleep 60
 done
 
-DOCKER_CMD="docker run --rm -t -v "/$PWD:/junk" busybox ls //junk "
+# Test that docker can allocate 80 and 443, get get busybox
+docker pull busybox:latest >/dev/null
 # Try the docker run command twice because of the really annoying mkdir /c: file exists bug
 # Apparently https://github.com/docker/for-win/issues/1560
-(sleep 1 && ( $DOCKER_CMD >/dev/null ) || (sleep 1 && $DOCKER_CMD >/dev/null )) || ( echo "docker is not running or can't do `$DOCKER_CMD`" && exit 3 )
+(sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:latest ls //tmp/junker99 >/dev/null ))
 
-if command -v ddev >/dev/null && [ "$(ddev version -j | jq -r .raw.commit)" \< "${MIN_DDEV_VERSION}" ] ; then
-  echo "ddev version in $(command -v ddev) is inadequate: $(ddev version -j | jq -r .raw.cli)"
+# Check that required commands are available.
+for command in curl jq zcat composer perl zip bats; do
+    command -v $command >/dev/null || ( echo "Did not find command installed '$command'" && exit 2 )
+done
+
+if [ "$(go env GOOS)" = "windows"  -a "$(git config core.autocrlf)" != "false" ] ; then
+ echo "git config core.autocrlf is not set to false on windows"
+ exit 3
+fi
+
+CURRENT_DDEV_VERSION=$(ddev --version  | awk '{ gsub(/^v/, "", $3); sub(/-.*$/, "", $3); print $3}' )
+CURRENT_DDEV_VERSION=$(ddev --version | awk '{ print $3 }')
+if command -v ddev >/dev/null && version_gt ${MIN_DDEV_VERSION} ${CURRENT_DDEV_VERSION} ; then
+  echo "ddev version in $(command -v ddev) is inadequate: $(ddev version -j | jq -r .raw.commit)"
   exit 4
 fi
 
-echo "Testbot appears to be sane"
+echo "=== testbot $HOSTNAME seems to be set up OK ==="


### PR DESCRIPTION
I found that I was getting deeper and deeper in a hole trying to sort out PRs in #137, #136, and #135, making changes in each, not good. 

This is aimed at testing only.
* Allow updating the configuration of buildkite testbots with current ddev
* Install ddev in circleci build
* Use homebrew for installs on the circleci build
* Stop installing composer on the host since we'll use `ddev composer` instead.
* Use simpler patterns deleting built artifacts (anticipating the tarball-split release)