### PR TITLE
Use the wording 'contribution event' instead of 'sprint', fixes #140

### DIFF
--- a/DRUPAL_MAINTAINER_README.md
+++ b/DRUPAL_MAINTAINER_README.md
@@ -1,19 +1,19 @@
 # Drupal Quicksprint Maintainer Notes
 
-Quicksprint is a basic toolkit to get people started with ddev and a Drupal codebase. This is intended for code sprints where lots of people need to get started with the same environment in a short period of time.
+Quicksprint is a basic toolkit to get people started with ddev and a Drupal codebase. This is intended for contribution events where lots of people need to get started with the same environment in a short period of time.
 
 There are two parts to this project:
 
-1. A build of the tarball that a sprint attendee needs (done by a maintainer using Linux or Mac OS, who should be reading this right now). The maintainer uses `package_drupal_script.sh` to create a tarball/zipball for sprint attendees to use.
-2. A released tarball/zipball that has everything ready for an ordinary sprint user to get set up fast. It includes a DRUPAL_SPRINTUSER_README.md to help them know what to do.
+1. A build of the tarball that a contribution event attendee needs (done by a maintainer using Linux or Mac OS, who should be reading this right now). The maintainer uses `package_drupal_script.sh` to create a tarball/zipball for sprint attendees to use.
+2. A released tarball/zipball that has everything ready for an ordinary contribution user to get set up fast. It includes a DRUPAL_SPRINTUSER_README.md to help them know what to do.
 
-Quicksprint uses [DDEV-Local](https://github.com/drud/ddev), docker, and a cloned Drupal8 repository to provide the tools to get people going quickly at a sprint.
+Quicksprint uses [DDEV-Local](https://github.com/drud/ddev), docker, and a cloned Drupal8 repository to provide the tools to get people going quickly at a contribution event.
 
 ## Creating a Sprint Package
 
 Quicksprint packages are built nightly and on tagged releases. We recommend downloading a tagged release from the GitHub [Releases page](https://github.com/drud/quicksprint/releases). You may create a custom build using this source repository.
 
-* To create a sprint package you will need to
+* To create a package you will need to
     * Confirm Docker is running.
     * Confirm docker-compose is available.
     * Make sure you have these packages on your build machine: curl jq zcat composer perl zip bats. You can run the tests/sanetestbot.sh script to test.
@@ -21,12 +21,12 @@ Quicksprint packages are built nightly and on tagged releases. We recommend down
 
 ## Distributing a Sprint Package
 
-There are several ways to distribute your sprint package such as through a peer-to-peer tool such as ResilioSync, USB flash drives or downloading from the releases page. This will depend on the size of your sprint.
+There are several ways to distribute your package such as through a peer-to-peer tool such as ResilioSync, USB flash drives or downloading from the releases page. This will depend on the size of your sprint.
 
 Method      | Sprint Size | Bandwidth | Other Considerations
 ----------  | ----------- | --------- | ----------------------
 ResilioSync | 100+ users  | N/A       | ResilioSync is not screen reader friendly and may be conflict with Firewall/Access Point security settings. Theoretically everyone would be able to get the files at the same time.
-USB drives  | varies      | N/A       | 30+ USB flash drives will work for large sprints, but people will be waiting in line.
+USB drives  | varies      | N/A       | 30+ USB flash drives will work for large events, but people will be waiting in line.
 Download    | 25 users    | 5 m/s     | Sprint venue may not be able to support large number of users pulling releases from github.
 
 #### USB Flash Drives

--- a/DRUPAL_MAINTAINER_README.md
+++ b/DRUPAL_MAINTAINER_README.md
@@ -5,7 +5,7 @@ Quicksprint is a basic toolkit to get people started with ddev and a Drupal code
 There are two parts to this project:
 
 1. A build of the tarball that a contribution event attendee needs (done by a maintainer using Linux or Mac OS, who should be reading this right now). The maintainer uses `package_drupal_script.sh` to create a tarball/zipball for sprint attendees to use.
-2. A released tarball/zipball that has everything ready for an ordinary contribution user to get set up fast. It includes a DRUPAL_SPRINTUSER_README.md to help them know what to do.
+2. A released tarball/zipball that has everything ready for an ordinary contributor to get set up fast. It includes a DRUPAL_SPRINTUSER_README.md to help them know what to do.
 
 Quicksprint uses [DDEV-Local](https://github.com/drud/ddev), docker, and a cloned Drupal8 repository to provide the tools to get people going quickly at a contribution event.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Quicksprint
 
-Quicksprint is a basic toolkit to get people started with ddev and a Drupal or TYPO3 codebase. This is intended for code sprints where lots of people need to get started with the same environment in a short period of time.
+Quicksprint is a basic toolkit to get people started with ddev and a Drupal or TYPO3 codebase. This is intended for contribution events where lots of people need to get started with the same environment in a short period of time.
 
-Maintainers create a download package for sprint users. Sprint users just have to use that package, they don't have to understand anything about how it's created.
+Maintainers create a download package for event users. Event users just have to use that package, they don't have to understand anything about how it's created.
 
 * Read the [Drupal Sprintuser README](DRUPAL_SPRINTUSER_README.md) if you're a Drupal user using the pre-built package.
 * Read the [Drupal Maintainer README](DRUPAL_MAINTAINER_README.md) if you're building or maintaining the package. This is a very small number of people, as the package is normally built by an automated system on CircleCI. 

--- a/install.sh
+++ b/install.sh
@@ -29,15 +29,16 @@ fi
 printf "
 ${GREEN}
 ####
-# This script will install everything you need to participate in this sprint.
+# This script will install everything you need to participate in this
+# contribution event.
 #
 # Feel free to first inspect the script before continuing if you like.
 #  -To do this just open it with a text editor
 #
 # It does the following:
-#  -Install Drud Technology's ddev local development tool
+#  -Install the DDEV-Local development tool
 #  -Copy required components to ~/sprint
-#  -Pre-loads docker images for the sprint toolkit:
+#  -Pre-loads docker images for the toolkit:
 #
 ####
 ${RESET}"
@@ -123,7 +124,7 @@ printf "
 ${GREEN}
 ######
 #
-# Your ddev and the sprint kit are now ready to use,
+# Your ddev and the contribution event kit are now ready to use,
 # Please open a NEW WINDOW to make sure you have any additional PATHs
 # and execute the following commands to start:
 #

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -14,7 +14,7 @@ export MSYS=winsymlinks:nativestrict
 # Maximise compression
 export XZ_OPT=-9e
 
-# This script creates a package of artifacts that can then be used at a code sprint working on Drupal 8.
+# This script creates a package of artifacts that can then be used at a contribution event working on Drupal 8.
 # It assumes it's being run in the repository root.
 
 STAGING_DIR_NAME=drupal_sprint_package
@@ -165,7 +165,7 @@ zip -9 -r -q drupal_sprint_package.no_extra_installs.${QUICKSPRINT_RELEASE}.zip 
 
 packages=$(ls ${STAGING_DIR_BASE}/drupal_sprint_package*${QUICKSPRINT_RELEASE}*)
 printf "${GREEN}####
-# The built sprint tarballs and zipballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}:
+# The built tarballs and zipballs are now in ${YELLOW}$STAGING_DIR_BASE${GREEN}:
 # ${packages:-}
 #
 # Package is built, staging directory remains in ${STAGING_DIR}.

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script creates a new drupal 8 instance in the current directory ready to sprint on an issue.
+# This script creates a new drupal 8 instance in the current directory.
 
 set -o errexit
 set -o pipefail

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -39,7 +39,7 @@ SOURCE_TARBALL_LOCATION=~/tmp/drupal_sprint_package.no_extra_installs.${QUICKSPR
 tar -C "$UNTAR_LOCATION" -zxf ${SOURCE_TARBALL_LOCATION:-}
 
 if [ ! -f "$UNTARRED_PACKAGE/DRUPAL_SPRINTUSER_README.md" -o ! -f "$UNTARRED_PACKAGE/COPYING" -o ! -d "$UNTARRED_PACKAGE/licenses" ]; then
-    echo "Packaged documents are missing from sprint package (in $UNTARRED_PACKAGE)"
+    echo "Packaged documents are missing from package (in $UNTARRED_PACKAGE)"
     exit 3
 fi
 


### PR DESCRIPTION
This just changes wording to "Contribution event' where possible, where it doesn't affect logic or require lots of effort to maintain the changes.