### PR TITLE
Use ddev stop instead of ddev rm, fixes #139

### DIFF
--- a/sprint/Readme.txt
+++ b/sprint/Readme.txt
@@ -11,7 +11,8 @@ Chat:        https://drupal.org/chat to join Drupal Slack or drupalchat.eu!
 Common ddev commands to know:
 
 ddev start (-h)                         [start project]
-ddev rm (-h)                            [stop and remove project, nothing lost]
+ddev stop (-h)                          [stop project, nothing lost]
+ddev poweroff                           [stop all projects and resources, nothing lost]
 ddev import-db --src=[path to db] (-h)  [import database]
 ddev help
 

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -22,7 +22,7 @@ function setup {
 function teardown {
     echo "# teardown beginning" >&3
 
-    ddev rm -R --omit-snapshot ${SPRINT_NAME}
+    ddev delete -O -y ${SPRINT_NAME}
     if [ ! -z "${SPRINTDIR}" -a ! -z "${SPRINT_NAME}" -a -d ${SPRINTDIR}/${SPRINT_NAME} ] ; then
         chmod -R u+w ${SPRINTDIR}/${SPRINT_NAME}
         rm -rf ${SPRINTDIR}/${SPRINT_NAME}

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -46,8 +46,8 @@ fi
 # Run install.sh
 (cd "$UNTARRED_PACKAGE" && printf 'y\ny\n' | ./install.sh) || ( echo "Failed to install.sh" && exit 4 )
 
-# Stop any running ddev instances, if we can
-ddev rm -a
+# Stop any running ddev instances
+ddev poweroff
 
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"


### PR DESCRIPTION
OP #139: Some usages have migrated in current ddev, although the previous ones still work, we might as well use the primary usage.