### PR TITLE
Build improvements for quicksprint

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -14,7 +14,7 @@ darwin)
 
     ;;
 windows)
-    choco upgrade -y mkcert ddev composer
+    choco upgrade -y mkcert ddev composer php
     composer self-update
     ;;
 esac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
     - run:
         name: "Publish Release on GitHub"
         command: |
-          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} $ARTIFACTS
+          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} $ARTIFACTS
 
 workflows:
   version: 2

--- a/DRUPAL_MAINTAINER_README.md
+++ b/DRUPAL_MAINTAINER_README.md
@@ -11,7 +11,7 @@ Quicksprint uses [DDEV-Local](https://github.com/drud/ddev), docker, and a clone
 
 ## Creating a Sprint Package
 
-Quicksprint packages are built nightly and on tagged releases. We recommend downloading a tagged release from the GitHub [Releases page](https://github.com/drud/quicksprint/releases). You may create a custom build using this source repository.
+Quicksprint packages are built nightly and on tagged releases. Please download a tagged release from the GitHub [Releases page](https://github.com/drud/quicksprint/releases) rather than bothering to build it yourself. But of course, you could create a custom build using this source repository.
 
 * To create a package you will need to
     * Confirm Docker is running.
@@ -22,6 +22,8 @@ Quicksprint packages are built nightly and on tagged releases. We recommend down
 ## Distributing a Sprint Package
 
 There are several ways to distribute your package such as through a peer-to-peer tool such as ResilioSync, USB flash drives or downloading from the releases page. This will depend on the size of your sprint.
+
+You must provide both the contents of the `drupal_sprint_package` *and* the `installs` tarball. (The installs package grew too big for github releases.)
 
 Method      | Sprint Size | Bandwidth | Other Considerations
 ----------  | ----------- | --------- | ----------------------

--- a/DRUPAL_SPRINTUSER_README.md
+++ b/DRUPAL_SPRINTUSER_README.md
@@ -5,12 +5,12 @@ This directory contains tools to get you started contributing to Drupal 8:
 * Drupal 8, already cloned with git
 * Docker CE
 * DDEV-Local (ddev) development environment
-* Additional tools for Windows
+* Additional tools including git for Windows
 
 ## Prerequisites
 
-* A computer with 8gb memory or greater.
-* Windows 7 or higher, MacOS El Capitan or higher or a recent/stable Linux distribution.
+* A computer with 6gb memory or greater.
+* Windows 7 or higher, MacOS Sierra or higher or a recent/stable Linux distribution.
 * A robust code editor such as Visual Studio Code, Atom, PhpStorm or Netbeans (this may be provided as part of this package).
 
 **⚠️ If your computer does not match a requirement, try the [Drupal quick-start](https://www.drupal.org/docs/8/install/quick-start-launch-a-local-demo-version-of-drupal-8-using-4-brief-steps)**! Now skip the steps below.


### PR DESCRIPTION
This is a few minor build improvements:

* ghr should not delete a release and recreate it, but rather just add to it
* buildkite testbots need to be configured with php as well as composer