### PR TITLE
Update default branch to 9.0.x and provide branch-switch script, fixes #153

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -135,10 +135,10 @@ git clone --config core.autocrlf=false --config core.eol=lf --config core.filemo
 pushd ${STAGING_DIR}/sprint/drupal8 >/dev/null
 cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 
-echo "Running composer install --quiet"
+set -x
 composer install --quiet
 composer require drush/drush:^10
-git checkout composer.json composer.lock
+set +x
 
 # The next line is a temporary workaround prevents the failures described in
 # https://github.com/drud/quicksprint/issues/151 and

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 # Base checkout should be of the 8.7.x branch
-SPRINT_BRANCH=8.8.x
+SPRINT_BRANCH=8.9.x
 
 # This makes git-bash actually try to create symlinks.
 # Use developer mode in Windows 10 so this doesn't require admin privs.

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -131,7 +131,7 @@ popd >/dev/null
 
 # clone or refresh d8 clone
 mkdir -p sprint
-git clone --config core.autocrlf=false --config core.eol=lf --quiet https://git.drupalcode.org/project/drupal.git ${STAGING_DIR}/sprint/drupal8 -b ${SPRINT_BRANCH}
+git clone --config core.autocrlf=false --config core.eol=lf --config core.filemode=false --quiet https://git.drupalcode.org/project/drupal.git ${STAGING_DIR}/sprint/drupal8 -b ${SPRINT_BRANCH}
 pushd ${STAGING_DIR}/sprint/drupal8 >/dev/null
 cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 # Base checkout should be of the 8.7.x branch
-SPRINT_BRANCH=8.9.x
+SPRINT_BRANCH=9.0.x
 
 # This makes git-bash actually try to create symlinks.
 # Use developer mode in Windows 10 so this doesn't require admin privs.
@@ -137,6 +137,9 @@ cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 
 echo "Running composer install --quiet"
 composer install --quiet
+composer require drush/drush:^10
+git checkout composer.json composer.lock
+
 # The next line is a temporary workaround prevents the failures described in
 # https://github.com/drud/quicksprint/issues/151 and
 # https://www.drupal.org/project/drupal/issues/3082866

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -131,7 +131,7 @@ popd >/dev/null
 
 # clone or refresh d8 clone
 mkdir -p sprint
-git clone --config core.autocrlf=false --config core.eol=lf --quiet https://git.drupal.org/project/drupal.git ${STAGING_DIR}/sprint/drupal8 -b ${SPRINT_BRANCH}
+git clone --config core.autocrlf=false --config core.eol=lf --quiet https://git.drupalcode.org/project/drupal.git ${STAGING_DIR}/sprint/drupal8 -b ${SPRINT_BRANCH}
 pushd ${STAGING_DIR}/sprint/drupal8 >/dev/null
 cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 

--- a/sprint/Readme.txt
+++ b/sprint/Readme.txt
@@ -19,3 +19,7 @@ ddev help
 For full ddev documentation see https://ddev.readthedocs.io/
 And support on Stack Overflow: https://stackoverflow.com/tags/ddev
 
+If you need to switch Drupal branches, for example to 9.0.x you can
+use the utility switch_branch.sh:
+./switch_branch.sh 9.0.x
+./switch_branch.sh 8.8.x

--- a/sprint/Readme.txt
+++ b/sprint/Readme.txt
@@ -20,6 +20,7 @@ For full ddev documentation see https://ddev.readthedocs.io/
 And support on Stack Overflow: https://stackoverflow.com/tags/ddev
 
 If you need to switch Drupal branches, for example to 9.0.x you can
-use the utility switch_branch.sh:
+use the utility switch_branch.sh. Although the script stashes changes to
+avoid losing your changes, you're best to save them away yourself first.
 ./switch_branch.sh 9.0.x
 ./switch_branch.sh 8.8.x

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script allows switching drupal branch, for example, from 8.9.x to 9.0.x
+# or back
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ $# != 1 ]]; then
+  echo "Please provide a branch to switch to. For example 'switch_branch.sh 9.0.x'"
+  exit 1
+fi
+
+
+target_branch=$1
+
+pushd drupal8
+set -x
+ddev exec "git stash && git reset --hard && git checkout ${target_branch} && git pull && git stash pop"
+ddev composer require drush/drush:^10
+ddev composer install
+ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time
+'
+set +x
+popd
+

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script allows switching drupal branch, for example, from 8.9.x to 9.0.x
+# This script allows switching drupal branch, for example, from 9.0.x to 8.9.x
 # or back
 
 set -o errexit
@@ -8,7 +8,7 @@ set -o pipefail
 set -o nounset
 
 if [[ $# != 1 ]]; then
-  echo "Please provide a branch to switch to. For example 'switch_branch.sh 9.0.x'"
+  echo "Please provide a branch to switch to. For example 'switch_branch.sh 8.9.x'"
   exit 1
 fi
 
@@ -18,11 +18,14 @@ target_branch=$1
 pushd drupal8
 set -x
 ddev start
-ddev exec "git stash save && git reset --hard && git checkout origin/${target_branch} && git fetch && git stash apply"
-ddev composer require drush/drush:^10
-ddev git checkout composer.json composer.lock
+ddev exec "git stash save"
+ddev exec "git reset --hard && git fetch && git checkout origin/${target_branch} "
 ddev composer install
+if [ "${target_branch}" '>' "9." ]; then ddev composer require drush/drush:^10; fi
+# Make sure that composer.json/lock don't show up in patches
+ddev exec "git checkout /var/www/html/composer.*"
+ddev exec "git stash apply || true"
 ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name=\'Drupal Contribution Time\'
 set +x
 popd
-
+echo "Switched to ${target_branch}"

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -20,8 +20,7 @@ set -x
 ddev exec "git stash && git reset --hard && git checkout ${target_branch} && git pull && git stash pop"
 ddev composer require drush/drush:^10
 ddev composer install
-ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time
-'
+ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name=\'Drupal Contribution Time\'
 set +x
 popd
 

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -18,13 +18,11 @@ target_branch=$1
 pushd drupal8
 set -x
 ddev start
-ddev exec "git stash save"
-ddev exec "git reset --hard && git fetch && git checkout origin/${target_branch} "
+ddev exec  "git fetch && git checkout origin/${target_branch}"
 ddev composer install
 if [ "${target_branch}" '>' "9." ]; then ddev composer require drush/drush:^10; fi
 # Make sure that composer.json/lock don't show up in patches
 ddev exec "git checkout /var/www/html/composer.*"
-ddev exec "git stash apply || true"
 ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name=\'Drupal Contribution Time\'
 set +x
 popd

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -17,8 +17,10 @@ target_branch=$1
 
 pushd drupal8
 set -x
-ddev exec "git stash && git reset --hard && git checkout ${target_branch} && git pull && git stash pop"
+ddev start
+ddev exec "git stash save && git reset --hard && git checkout origin/${target_branch} && git fetch && git stash apply"
 ddev composer require drush/drush:^10
+ddev git checkout composer.json composer.lock
 ddev composer install
 ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name=\'Drupal Contribution Time\'
 set +x

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -43,9 +43,8 @@ ddev start || (printf "${RED}ddev start failed.${RESET}" && exit 101)
 printf "${YELLOW}Running git fetch && git checkout origin/${SPRINT_BRANCH}.${RESET}...\n"
 ddev exec "(git fetch && git checkout 'origin/${SPRINT_BRANCH}') || (echo 'ddev exec...git checkout failed' && exit 102)"
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
-ddev composer require drush/drush:^10
 ddev composer install
-ddev exec git checkout /var/www/html/composer.*
+ddev exec "git checkout /var/www/html/composer.*"
 
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
 ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -43,8 +43,8 @@ ddev start || (printf "${RED}ddev start failed.${RESET}" && exit 101)
 printf "${YELLOW}Running git fetch && git checkout origin/${SPRINT_BRANCH}.${RESET}...\n"
 ddev exec "(git fetch && git checkout 'origin/${SPRINT_BRANCH}') || (echo 'ddev exec...git checkout failed' && exit 102)"
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
-ddev composer install
 ddev composer require drush/drush:^10
+ddev composer install
 ddev exec git checkout /var/www/html/composer.*
 
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-SPRINT_BRANCH=8.8.x
+SPRINT_BRANCH=8.9.x
 
 RED='\033[31m'
 GREEN='\033[32m'

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -40,8 +40,8 @@ ddev config global --instrumentation-opt-in=false >/dev/null
 printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}\n"
 printf "${YELLOW}Running ddev start...YOU MAY BE ASKED for your sudo password to add a hostname to /etc/hosts${RESET}\n"
 ddev start || (printf "${RED}ddev start failed.${RESET}" && exit 101)
-printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.${RESET}...\n"
-ddev exec "(git fetch && git reset --hard 'origin/${SPRINT_BRANCH}') || (echo 'ddev exec...git reset failed' && exit 102)"
+printf "${YELLOW}Running git fetch && git checkout origin/${SPRINT_BRANCH}.${RESET}...\n"
+ddev exec "(git fetch && git checkout 'origin/${SPRINT_BRANCH}') || (echo 'ddev exec...git checkout failed' && exit 102)"
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
 ddev composer install
 ddev composer require drush/drush:^10

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -34,7 +34,7 @@ fi
 cd "${SPRINTNAME}/drupal8"
 echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which ddev)"
 
-ddev config --docroot . --project-type drupal8 --php-version=7.2 --http-port=8080 --https-port=8443 --project-name="sprint-${TIMESTAMP}"
+ddev config --docroot . --project-type drupal8 --php-version=7.3 --http-port=8080 --https-port=8443 --project-name="sprint-${TIMESTAMP}"
 
 ddev config global --instrumentation-opt-in=false >/dev/null
 printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}\n"

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-SPRINT_BRANCH=8.9.x
+SPRINT_BRANCH=9.0.x
 
 RED='\033[31m'
 GREEN='\033[32m'
@@ -44,6 +44,9 @@ printf "${YELLOW}Running git fetch && git reset --hard origin/${SPRINT_BRANCH}.$
 ddev exec "(git fetch && git reset --hard 'origin/${SPRINT_BRANCH}') || (echo 'ddev exec...git reset failed' && exit 102)"
 printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
 ddev composer install
+ddev composer require drush/drush:^10
+ddev exec git checkout /var/www/html/composer.*
+
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
 ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
 printf "${RESET}"

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -5,7 +5,7 @@
 
 function setup {
     echo "# setup beginning" >&3
-    export SPRINT_BRANCH=8.8.x
+    export SPRINT_BRANCH=8.9.x
 
     export SPRINTDIR=~/sprint
     # DRUD_NONINTERACTIVE causes ddev not to try to use sudo and add the hostname

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -5,7 +5,7 @@
 
 function setup {
     echo "# setup beginning" >&3
-    export SPRINT_BRANCH=8.9.x
+    export SPRINT_BRANCH=9.0.x
 
     export SPRINTDIR=~/sprint
     # DRUD_NONINTERACTIVE causes ddev not to try to use sudo and add the hostname

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -34,7 +34,7 @@ function teardown {
     cd ${SPRINTDIR}/${SPRINT_NAME}/drupal8
     [ "$(git config core.eol)" = "lf" ]
     [ "$(git config core.autocrlf)" = "false" ]
-    [ "$(git rev-parse --abbrev-ref HEAD)" = ${SPRINT_BRANCH} ]
+    git log -n 1 --pretty=%d HEAD | grep "origin/${SPRINT_BRANCH}"
 }
 
 @test "check ddev project status and router status, check http status" {
@@ -60,5 +60,10 @@ function teardown {
     URL="http://${DHOST}:${HTTP_PORT}"
     CURL="curl --fail -H 'Host: ${NAME}.ddev.site' --silent --output /dev/null --url $URL"
     echo "# curl: $CURL" >&3
+    ${CURL}
+
+    echo "# Testing switch_branch.sh"
+    cd ..
+    ./switch_branch.sh 8.9.x
     ${CURL}
 }


### PR DESCRIPTION
This does a few minor fixups in preparation for Drupal 9.0.x and Drupalcon Amsterdam:

* Update the default branch for checkout to 9.0.x and include drush 10
* Provide a script in every sprint directory called switch_branch.sh that allows switching, for example to 8.9.x. The Readme.txt in the script directory explains it, but `./switch_branch.sh 8.9.x` or `./switch_branch.sh 8.8.x`
* Change the build to use git.drupalcode.org for the original clone instead of older git.drupal.org
* Change the default PHP version to current stable 7.3