### PR TITLE
Go back to 8.9.x, scale back switch_branch.sh

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 # Base checkout should be of the 8.7.x branch
-SPRINT_BRANCH=9.0.x
+SPRINT_BRANCH=8.9.x
 
 # This makes git-bash actually try to create symlinks.
 # Use developer mode in Windows 10 so this doesn't require admin privs.

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -137,7 +137,6 @@ cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
 
 set -x
 composer install --quiet
-composer require drush/drush:^10
 set +x
 
 # The next line is a temporary workaround prevents the failures described in

--- a/sprint/Readme.txt
+++ b/sprint/Readme.txt
@@ -19,8 +19,12 @@ ddev help
 For full ddev documentation see https://ddev.readthedocs.io/
 And support on Stack Overflow: https://stackoverflow.com/tags/ddev
 
-If you need to switch Drupal branches, for example to 9.0.x you can
+If you need to switch Drupal branches, for example to 9.0.x, you can
 use the utility switch_branch.sh. Although the script stashes changes to
 avoid losing your changes, you're best to save them away yourself first.
+switch_branch.sh also drops your existing database, so after running it
+you'll need to do a manual web-based install.
+
+Examples:
 ./switch_branch.sh 9.0.x
 ./switch_branch.sh 8.8.x

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script allows switching drupal branch, for example, from 9.0.x to 8.9.x
+# This script allows switching drupal branch, for example, from 8.9.x to 9.0.x
 # or back
 
 set -o errexit
@@ -18,12 +18,13 @@ target_branch=$1
 pushd drupal8
 set -x
 ddev start
-ddev exec  "git fetch && git checkout origin/${target_branch}"
+ddev exec  "git fetch && git stash save && git checkout origin/${target_branch}"
 ddev composer install
-if [ "${target_branch}" '>' "9." ]; then ddev composer require drush/drush:^10; fi
+#if [ "${target_branch}" '>' "9." ]; then ddev composer require drush/drush:^10; fi
 # Make sure that composer.json/lock don't show up in patches
-ddev exec "git checkout /var/www/html/composer.*"
-ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name=\'Drupal Contribution Time\'
+ddev exec "git stash apply && git checkout /var/www/html/composer.*"
+#ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name=\'Drupal Contribution Time\'
 set +x
 popd
-echo "Switched to ${target_branch}"
+echo "Switched to ${target_branch}; you can now install via the web installer"
+ddev list

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -23,6 +23,7 @@ ddev composer install
 #if [ "${target_branch}" '>' "9." ]; then ddev composer require drush/drush:^10; fi
 # Make sure that composer.json/lock don't show up in patches
 ddev exec "( git stash apply || true )"
+ddev exec drush sql-drop -y
 set +x
 popd
 echo "Switched to ${target_branch}; you can now install via the web installer"

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -22,8 +22,7 @@ ddev exec  "git fetch && git stash save && git checkout origin/${target_branch}"
 ddev composer install
 #if [ "${target_branch}" '>' "9." ]; then ddev composer require drush/drush:^10; fi
 # Make sure that composer.json/lock don't show up in patches
-ddev exec "git stash apply && git checkout /var/www/html/composer.*"
-#ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name=\'Drupal Contribution Time\'
+ddev exec "( git stash apply || true )"
 set +x
 popd
 echo "Switched to ${target_branch}; you can now install via the web installer"

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -20,10 +20,8 @@ set -x
 ddev start
 ddev exec  "git fetch && git stash save && git checkout origin/${target_branch}"
 ddev composer install
-#if [ "${target_branch}" '>' "9." ]; then ddev composer require drush/drush:^10; fi
-# Make sure that composer.json/lock don't show up in patches
 ddev exec "( git stash apply || true )"
-ddev exec drush sql-drop -y
+echo "DROP DATABASE db; CREATE DATABASE db; " | ddev mysql -uroot -proot
 set +x
 popd
 echo "Switched to ${target_branch}; you can now install via the web installer"

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-SPRINT_BRANCH=9.0.x
+SPRINT_BRANCH=8.9.x
 
 RED='\033[31m'
 GREEN='\033[32m'

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -54,7 +54,7 @@ function teardown {
     STATUS=$(echo ${DESCRIBE} | jq -r ".raw.status")
     [ "$STATUS" = "running" ]
 
-    echo "# Testing curl reachability" >&3
+    echo "# Testing curl reachability for ${NAME}.ddev.site" >&3
     NAME=$(echo ${DESCRIBE} | jq -r ".raw.name")
     HTTP_PORT=$(echo ${DESCRIBE} | jq -r ".raw.router_http_port")
     URL="http://${DHOST}:${HTTP_PORT}"
@@ -65,6 +65,7 @@ function teardown {
     echo "# Testing switch_branch.sh"
     cd ..
     ./switch_branch.sh 9.0.x
+    echo "# Testing curl reachability for ${NAME}.ddev.site" >&3
     echo "# curl: $CURL" >&3
     ${CURL}
 }

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -5,7 +5,7 @@
 
 function setup {
     echo "# setup beginning" >&3
-    export SPRINT_BRANCH=9.0.x
+    export SPRINT_BRANCH=8.9.x
 
     export SPRINTDIR=~/sprint
     # DRUD_NONINTERACTIVE causes ddev not to try to use sudo and add the hostname
@@ -64,6 +64,6 @@ function teardown {
 
     echo "# Testing switch_branch.sh"
     cd ..
-    ./switch_branch.sh 8.9.x
+    ./switch_branch.sh 9.0.x
     ${CURL}
 }

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -58,12 +58,13 @@ function teardown {
     NAME=$(echo ${DESCRIBE} | jq -r ".raw.name")
     HTTP_PORT=$(echo ${DESCRIBE} | jq -r ".raw.router_http_port")
     URL="http://${DHOST}:${HTTP_PORT}"
-    CURL="curl --fail -H 'Host: ${NAME}.ddev.site' --silent --output /dev/null --url $URL"
+    CURL="curl -lL -s --fail -H 'Host: ${NAME}.ddev.site' --silent --output /dev/null --url $URL"
     echo "# curl: $CURL" >&3
     ${CURL}
 
     echo "# Testing switch_branch.sh"
     cd ..
     ./switch_branch.sh 9.0.x
+    echo "# curl: $CURL" >&3
     ${CURL}
 }


### PR DESCRIPTION
Unfortunately, 9.0.x and Drush 10.x aren't going to be compatible yet, and we don't know how to do an automated install without drush. 

This PR 
* goes back to using 8.9.x
* not installing site-local drush at all, which prevents problems with the composer.json anyway.
* switch_branch.sh doesn't try to do a drupal install
* switch_branch.sh drops an existing db.

https://drupal.slack.com/archives/C62H9CWQM/p1571676244050500

https://drupal.slack.com/archives/C62H9CWQM/p1571680129057800