### PR TITLE
Remove doubled php installs from ubuntu and homebrew, fixes #161

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -14,7 +14,7 @@ darwin)
 
     ;;
 windows)
-    choco uninstall -y --force composer php
+    choco uninstall -y --force -n composer php
     # Prevent choco from getting php 7.4 at this point.
     choco upgrade -y --version 7.3.12 php
     choco upgrade -y mkcert ddev composer

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -14,6 +14,7 @@ darwin)
 
     ;;
 windows)
+    choco uninstall -y --force composer php
     # Prevent choco from getting php 7.4 at this point.
     choco upgrade -y --version 7.3.12 php
     choco upgrade -y mkcert ddev composer

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -14,7 +14,9 @@ darwin)
 
     ;;
 windows)
-    choco upgrade -y mkcert ddev composer php
+    # Prevent choco from getting php 7.4 at this point.
+    choco upgrade -y --version 7.3.12 php
+    choco upgrade -y mkcert ddev composer
     composer self-update
     ;;
 esac

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -14,10 +14,7 @@ darwin)
 
     ;;
 windows)
-    choco uninstall -y --force composer php
-    # Prevent choco from getting php 7.4 at this point.
-    choco upgrade -y --version 7.3.12 php
-    choco upgrade -y mkcert ddev composer
+    choco upgrade -y mkcert ddev composer php
     composer self-update
     ;;
 esac

--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -5,10 +5,8 @@ set -x
 
 # Basic tools
 
-v=php7.2
-sudo add-apt-repository -y ppa:ondrej/php
 sudo apt-get update -qq
-sudo apt-get install -y -qq jq realpath zip ${v} ${v}-bcmath ${v}-curl ${v}-cgi ${v}-cli ${v}-common ${v}-fpm ${v}-gd ${v}-intl ${v}-json ${v}-mysql ${v}-mbstring  ${v}-opcache ${v}-soap ${v}-readline ${v}-xdebug ${v}-xml ${v}-xmlrpc ${v}-zip;
+sudo apt-get install -y -qq jq realpath zip
 
 # Remove any existing docker
 sudo apt-get remove docker docker-engine docker.io
@@ -34,9 +32,7 @@ echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 . ~/.bashrc
 
 brew update && brew tap drud/ddev
-for item in mkcert ddev composer php docker-compose; do
-    brew install $item || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item
-done
+brew install mkcert ddev composer php docker-compose
 
 # install recent bats bash testing framework
 BATS_TAG=v1.1.0

--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -5,8 +5,10 @@ set -x
 
 # Basic tools
 
+v=php7.3
+sudo add-apt-repository -y ppa:ondrej/php
 sudo apt-get update -qq
-sudo apt-get install -y -qq jq realpath zip
+sudo apt-get install -y -qq jq realpath zip ${v} ${v}-bcmath ${v}-curl ${v}-cgi ${v}-cli ${v}-common ${v}-fpm ${v}-gd ${v}-intl ${v}-json ${v}-mysql ${v}-mbstring  ${v}-opcache ${v}-soap ${v}-readline ${v}-xdebug ${v}-xml ${v}-xmlrpc ${v}-zip;
 
 # Remove any existing docker
 sudo apt-get remove docker docker-engine docker.io
@@ -23,6 +25,11 @@ sudo add-apt-repository \
 sudo apt-get update -qq
 sudo apt-get install -qq docker-ce
 
+sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+sudo php -r "unlink('composer-setup.php');"
+
+
 if [ ! -d /home/linuxbrew/.linuxbrew/bin ] ; then
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
 fi
@@ -32,7 +39,7 @@ echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 . ~/.bashrc
 
 brew update && brew tap drud/ddev
-brew install mkcert ddev composer php docker-compose
+brew install mkcert ddev docker-compose
 
 # install recent bats bash testing framework
 BATS_TAG=v1.1.0


### PR DESCRIPTION
Nightly builds have been failing due to apparent differences between the apt install of php and the brew install. Hopefully this minor change to the setup script will help.