### PR TITLE
Change default branch to 9.0.x

### DIFF
--- a/DRUPAL_MAINTAINER_README.md
+++ b/DRUPAL_MAINTAINER_README.md
@@ -54,5 +54,3 @@ There are some better tools to automate USB flash drive imaging, but your mileag
 * Your users will then download and unarchive the tarball or zipball.
 * Run install.sh from the unarchived directory; (Windows users must work in git-bash).
 * After installation, users can start up an instance by cd-ing to ~/sprint and running ./start_sprint.sh. 
-
-At this point the plain vanilla git-checked-out drupal8 HEAD version should be running at http://drupal8.ddev.site.

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 # Base checkout should be of the 8.7.x branch
-SPRINT_BRANCH=8.9.x
+SPRINT_BRANCH=9.0.x
 
 # This makes git-bash actually try to create symlinks.
 # Use developer mode in Windows 10 so this doesn't require admin privs.

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -131,9 +131,9 @@ popd >/dev/null
 
 # clone or refresh d8 clone
 mkdir -p sprint
-git clone --config core.autocrlf=false --config core.eol=lf --config core.filemode=false --quiet https://git.drupalcode.org/project/drupal.git ${STAGING_DIR}/sprint/drupal8 -b ${SPRINT_BRANCH}
-pushd ${STAGING_DIR}/sprint/drupal8 >/dev/null
-cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal8/.gitignore
+git clone --config core.autocrlf=false --config core.eol=lf --config core.filemode=false --quiet https://git.drupalcode.org/project/drupal.git ${STAGING_DIR}/sprint/drupal -b ${SPRINT_BRANCH}
+pushd ${STAGING_DIR}/sprint/drupal >/dev/null
+cp ${REPO_DIR}/example.gitignore ${STAGING_DIR}/sprint/drupal/.gitignore
 
 set -x
 composer install --quiet

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -3,7 +3,7 @@
 # This script allows switching drupal branch, for example, from 9.0.x to 8.9.x
 # or back
 
-set -o errexit pipefail nounset
+set -o errexit -o pipefail -o nounset
 
 if [[ $# != 1 ]]; then
   echo "Please provide a branch to switch to. For example './switch_branch.sh 8.9.x'"
@@ -20,7 +20,8 @@ ddev exec  "git fetch && git stash save && git checkout origin/${target_branch}"
 ddev composer install
 ddev exec "( git stash apply || true )"
 echo "DROP DATABASE db; CREATE DATABASE db; " | ddev mysql -uroot -proot
+ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
 set +x
-popd
-echo "Switched to ${target_branch}; you can now install via the web installer"
+popd >/dev/null
+echo "Switched to ${target_branch}"
 ddev list

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -6,7 +6,7 @@
 set -o errexit pipefail nounset
 
 if [[ $# != 1 ]]; then
-  echo "Please provide a branch to switch to. For example 'switch_branch.sh 8.9.x'"
+  echo "Please provide a branch to switch to. For example './switch_branch.sh 8.9.x'"
   exit 1
 fi
 

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -15,7 +15,7 @@ fi
 
 target_branch=$1
 
-pushd drupal8
+pushd drupal
 set -x
 ddev start
 ddev exec  "git fetch && git stash save && git checkout origin/${target_branch}"

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script allows switching drupal branch, for example, from 8.9.x to 9.0.x
+# This script allows switching drupal branch, for example, from 9.0.x to 8.9.x
 # or back
 
 set -o errexit

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -3,9 +3,7 @@
 # This script allows switching drupal branch, for example, from 9.0.x to 8.9.x
 # or back
 
-set -o errexit
-set -o pipefail
-set -o nounset
+set -o errexit pipefail nounset
 
 if [[ $# != 1 ]]; then
   echo "Please provide a branch to switch to. For example 'switch_branch.sh 8.9.x'"

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-SPRINT_BRANCH=8.9.x
+SPRINT_BRANCH=9.0.x
 
 RED='\033[31m'
 GREEN='\033[32m'

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script creates a new drupal 8 instance in the current directory.
+# This script creates a new drupal instance in the current directory.
 
 set -o errexit
 set -o pipefail
@@ -31,7 +31,7 @@ else
     exit 1
 fi
 
-cd "${SPRINTNAME}/drupal8"
+cd "${SPRINTNAME}/drupal"
 echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which ddev)"
 
 ddev config --docroot . --project-type drupal8 --php-version=7.3 --http-port=8080 --https-port=8443 --project-name="sprint-${TIMESTAMP}"

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -64,7 +64,7 @@ function teardown {
 
     echo "# Testing switch_branch.sh"
     cd ..
-    ./switch_branch.sh 9.1.x
+    ./switch_branch.sh 8.9.x
     echo "# Testing curl reachability for ${NAME}.ddev.site" >&3
     echo "# curl: $CURL" >&3
     ${CURL}

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -5,7 +5,7 @@
 
 function setup {
     echo "# setup beginning" >&3
-    export SPRINT_BRANCH=8.9.x
+    export SPRINT_BRANCH=9.0.x
 
     export SPRINTDIR=~/sprint
     # DRUD_NONINTERACTIVE causes ddev not to try to use sudo and add the hostname
@@ -64,7 +64,7 @@ function teardown {
 
     echo "# Testing switch_branch.sh"
     cd ..
-    ./switch_branch.sh 9.0.x
+    ./switch_branch.sh 9.1.x
     echo "# Testing curl reachability for ${NAME}.ddev.site" >&3
     echo "# curl: $CURL" >&3
     ${CURL}

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -31,14 +31,14 @@ function teardown {
 }
 
 @test "check git configuration" {
-    cd ${SPRINTDIR}/${SPRINT_NAME}/drupal8
+    cd ${SPRINTDIR}/${SPRINT_NAME}/drupal
     [ "$(git config core.eol)" = "lf" ]
     [ "$(git config core.autocrlf)" = "false" ]
     git log -n 1 --pretty=%d HEAD | grep "origin/${SPRINT_BRANCH}"
 }
 
 @test "check ddev project status and router status, check http status" {
-    cd ${SPRINTDIR}/${SPRINT_NAME}/drupal8
+    cd ${SPRINTDIR}/${SPRINT_NAME}/drupal
     DESCRIBE=$(ddev describe -j)
 
     ROUTER_STATUS=$(echo "${DESCRIBE}" | jq -r ".raw.router_status" )

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -64,7 +64,7 @@ function teardown {
 
     echo "# Testing switch_branch.sh"
     cd ..
-    ./switch_branch.sh 8.9.x
+    ./switch_branch.sh "8.9.x"
     echo "# Testing curl reachability for ${NAME}.ddev.site" >&3
     echo "# curl: $CURL" >&3
     ${CURL}


### PR DESCRIPTION
In preparation for Winter and Sprint Drupalcamps, get ready for a release. 

9.0.x is likely to be the most popular branch for core dev, so switch to that. 

drush 8.3.1 is now in the current release of ddev and works with drupal 9. 