### PR TITLE
Temporarily revert to older docker desktop for windows, for #166

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -32,7 +32,7 @@ GIT_LATEST_RELEASE="$(curl -L -s -H 'Accept: application/json' https://github.co
 GIT_DOWNLOAD_URL="https://github.com/git-for-windows/git/releases/download/v${GIT_LATEST_RELEASE}.windows.1/Git-${GIT_LATEST_RELEASE}-64-bit.exe"
 
 
-DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe ${TOOLBOX_DOWNLOAD_URL} ${GIT_DOWNLOAD_URL}"
+DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/40693/Docker%20Desktop%20Installer.exe ${TOOLBOX_DOWNLOAD_URL} ${GIT_DOWNLOAD_URL}"
 
 RED='\033[31m'
 GREEN='\033[32m'


### PR DESCRIPTION
Temporarily revert to older docker desktop for windows, fixes #166 - this will need to be reverted when there is an actual "stable" docker desktop.