### PR TITLE
Minor maintenance to switch_branch and start_sprint

### DIFF
--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -47,7 +47,7 @@ ddev composer install
 ddev exec "git checkout /var/www/html/composer.*"
 
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
-ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
+ddev exec "drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time'"
 printf "${RESET}"
 ddev describe
 

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -21,6 +21,7 @@ function setup {
 
 function teardown {
     echo "# teardown beginning" >&3
+    export SPRINT_NAME=$(cat "${SPRINTDIR}/.test_sprint_name.txt")
 
     ddev delete -O -y ${SPRINT_NAME}
     if [ ! -z "${SPRINTDIR}" -a ! -z "${SPRINT_NAME}" -a -d ${SPRINTDIR}/${SPRINT_NAME} ] ; then
@@ -31,6 +32,7 @@ function teardown {
 }
 
 @test "check git configuration" {
+    export SPRINT_NAME=$(cat "${SPRINTDIR}/.test_sprint_name.txt")
     cd ${SPRINTDIR}/${SPRINT_NAME}/drupal
     [ "$(git config core.eol)" = "lf" ]
     [ "$(git config core.autocrlf)" = "false" ]
@@ -38,6 +40,7 @@ function teardown {
 }
 
 @test "check ddev project status and router status, check http status" {
+    export SPRINT_NAME=$(cat "${SPRINTDIR}/.test_sprint_name.txt")
     cd ${SPRINTDIR}/${SPRINT_NAME}/drupal
     DESCRIBE=$(ddev describe -j)
 


### PR DESCRIPTION
This PR just fixes up some annoying minor problem

* the `drush si` in start_sprint.sh now properly sets the site name. It was being lost before due to quoting issues.
* Minor improvements to switch_branch.sh so it doesn't stumble on the replacement of coder module (which includes its git folder and shouldn't)
* Minor env additions to tests to try to get them to fail more gracefully.