### PR TITLE
Revert "Temporarily revert to older docker desktop for windows, fixes #166

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -32,7 +32,7 @@ GIT_LATEST_RELEASE="$(curl -L -s -H 'Accept: application/json' https://github.co
 GIT_DOWNLOAD_URL="https://github.com/git-for-windows/git/releases/download/v${GIT_LATEST_RELEASE}.windows.1/Git-${GIT_LATEST_RELEASE}-64-bit.exe"
 
 
-DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/40693/Docker%20Desktop%20Installer.exe ${TOOLBOX_DOWNLOAD_URL} ${GIT_DOWNLOAD_URL}"
+DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe ${TOOLBOX_DOWNLOAD_URL} ${GIT_DOWNLOAD_URL}"
 
 RED='\033[31m'
 GREEN='\033[32m'


### PR DESCRIPTION
Docker 2.2.0.3 should be fine now. Automatically gathering it as we did before.

This reverts commit 6a6727dcea1b3d7613f213ee445c929ef8370b69.