### PR TITLE
Use mariadb 10.3 for latest drupal 9.0.x

### DIFF
--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -34,7 +34,7 @@ fi
 cd "${SPRINTNAME}/drupal"
 echo "Using ddev version $(ddev version| awk '/^cli/ { print $2}') from $(which ddev)"
 
-ddev config --docroot . --project-type drupal8 --php-version=7.3 --http-port=8080 --https-port=8443 --project-name="sprint-${TIMESTAMP}"
+ddev config --docroot . --project-type drupal8 --php-version=7.3 --mariadb-version=10.3 --http-port=8080 --https-port=8443 --project-name="sprint-${TIMESTAMP}"
 
 ddev config global --instrumentation-opt-in=false >/dev/null
 printf "${YELLOW}Configuring your fresh Drupal8 instance. This takes a few minutes.${RESET}\n"


### PR DESCRIPTION
Last night Drupal 9 added a commit that requires MariaDB 10.3, so the default 10.2 won't work for installation now. 

See https://www.drupal.org/project/drupal/issues/3120124

This changes the `ddev config` in the start_sprint.sh to use --mariadb-version=10.3

This will require a new release for MidCamp.