### PR TITLE
Temporarily roll back to Docker Windows 2.2.0.3 because 2.2.0.4 is bad

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -32,7 +32,7 @@ GIT_LATEST_RELEASE="$(curl -L -s -H 'Accept: application/json' https://github.co
 GIT_DOWNLOAD_URL="https://github.com/git-for-windows/git/releases/download/v${GIT_LATEST_RELEASE}.windows.1/Git-${GIT_LATEST_RELEASE}-64-bit.exe"
 
 
-DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe ${TOOLBOX_DOWNLOAD_URL} ${GIT_DOWNLOAD_URL}"
+DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/42716/Docker%20Desktop%20Installer.exe ${TOOLBOX_DOWNLOAD_URL} ${GIT_DOWNLOAD_URL}"
 
 RED='\033[31m'
 GREEN='\033[32m'


### PR DESCRIPTION
Docker for Windows 2.2.0.4, current "stable" has a huge flaw that prevents git checkout inside container. see https://github.com/docker/for-win/issues/6016

So we'll temporarily stop using "stable". This uses 2.2.0.3, which was working OK.