### PR TITLE
Update DRUPAL_SPRINTUSER_README.md

### DIFF
--- a/DRUPAL_SPRINTUSER_README.md
+++ b/DRUPAL_SPRINTUSER_README.md
@@ -1,16 +1,16 @@
 # Drupal Contribution Package
 
-This directory contains tools to get you started contributing to Drupal:
+This package contains tools to get you started contributing to Drupal:
 
 * Drupal, already cloned with git
-* Docker CE
+* Docker Desktop for Mac or Windows
 * DDEV-Local (ddev) development environment
 * Additional tools including git for Windows
 
 ## Prerequisites
 
 * A computer with 6gb memory or greater.
-* Windows 7 or higher, MacOS Sierra or higher or a recent/stable Linux distribution.
+* Windows 7 or higher, MacOS High Sierra or higher or a recent/stable Linux distribution.
 * A robust code editor such as Visual Studio Code, Atom, PhpStorm or Netbeans (this may be provided as part of this package).
 
 **⚠️ If your computer does not match a requirement, try the [Drupal quick-start](https://www.drupal.org/docs/8/install/quick-start-launch-a-local-demo-version-of-drupal-8-using-4-brief-steps)**! Now skip the steps below.
@@ -28,22 +28,22 @@ This directory contains tools to get you started contributing to Drupal:
 
 Use one of the options below to get the files.
 
-* USB Drive - Copy drupal_sprint_package.RELEASE.zip and Docker installer for your Operating System from the USB drive to your Desktop.
-* ResilioSync - Find the folder/directory that was downloaded and copy its contents to your Desktop.
-* GitHub - Download drupal_sprint_package.RELEASE.zip from https://github.com/drud/quicksprint/releases. Also download quicksprint_thirdparty_installs.RELEASE.zip if you need Docker and/or Git.
+* GitHub - Download `drupal_sprint_package.<RELEASE>.zip` from https://github.com/drud/quicksprint/releases. Also download `quicksprint_thirdparty_installs.<RELEASE>>.zip` if you need Docker and/or Git.
+* USB Drive (available at some conferences) - Copy drupal_sprint_package.RELEASE.zip and Docker installer for your Operating System from the USB drive to your Desktop.
+* ResilioSync (available at some conferences) - Find the folder/directory that was downloaded and copy its contents to your Desktop.
 
 
 <a name="extract-files"></a>
 ### 2. drupal_sprint_package directory
 
-Extract the drupal_sprint_package.RELEASE.zip file, and open or browse the contents. This is the sprint package directory.
+Extract the `drupal_sprint_package.<RELEASE>.zip` file, and open or browse the contents. This is the sprint package directory.
 
-Extract the quicksprint_thirdparty_installs.RELEASE.zip if downloaded, and open or browse the contents and find the /installs folder. This is the third party installs directory.
+Extract the `quicksprint_thirdparty_installs.<RELEASE>.zip` if downloaded, and open or browse the contents and find the /installs folder. This is the third party installs directory.
 
 <a name="install"></a>
 ### 3. Install Docker and Other Requirements
 
-#### 3.1 Docker CE or Docker Toolbox
+#### 3.1 Docker Desktop or Docker Toolbox
 
 * **Windows users install git:** First, install Git For Windows from the **third party installs** directory. The version here is newer than you might have on your computer if you already have it, so install if you don't have Git for Windows or have a version less than 2.21.0.
 * **All users:** Find the Docker installer for your Operating System underneath the **third party installs** directory. It is important to install the version of Docker provided for compatibility with the tools.
@@ -58,9 +58,9 @@ Extract the quicksprint_thirdparty_installs.RELEASE.zip if downloaded, and open 
 
 **⚠️Docker Toolbox Users:** Run "Docker Quickstart Terminal" to start docker running.
 
-**⚠️Docker for Windows and Docker for Mac** Start the docker application
+**⚠️Docker Desktop for Windows and Docker Desktop for Mac** Start the docker application
 
-**⚠️Docker for Windows**: You *must* share the C: drive (preferably all drives, or any other drive your home directory may be on) under Docker->Settings->Shared Drives.
+**⚠️Docker Desktop for Windows**: You *must* share the C: drive (preferably all drives, or any other drive your home directory may be on) under Docker->Settings->Shared Drives.
 
 **⚠️All users** Additional Docker **installation** troubleshooting and installation documentation is available at [ddev docker instructions](https://ddev.readthedocs.io/en/stable/users/docker_installation/).
 
@@ -75,11 +75,11 @@ Open your Terminal application. If you already had a window open, close it and o
 
 Operating System | Docker Version | Program
 ---------------- | -------------- | ----------------
-Windows 10 Pro, Enterprise (HyperV enabled) | Docker CE | Git Bash
+Windows 10 Pro, Enterprise (HyperV enabled) | Docker Desktop | Git Bash
 Windows 10 Home | Docker Toolbox | Docker Quickstart Terminal
 Windows 7  | Docker Toolbox | Docker Quickstart Terminal
-MacOS | Docker CE | Terminal.app or your preferred terminal application
-Linux | Docker CE | Your preferred terminal application
+MacOS | Docker Desktop | Terminal.app or your preferred terminal application
+Linux | Docker-ce | Your preferred terminal application
 
 <a name="install-tools"></a>
 ### 5. Install Contribution Tools

--- a/DRUPAL_SPRINTUSER_README.md
+++ b/DRUPAL_SPRINTUSER_README.md
@@ -36,9 +36,9 @@ Use one of the options below to get the files.
 <a name="extract-files"></a>
 ### 2. drupal_sprint_package directory
 
-Extract the drupal_sprint_package.RELEASE.zip file, and open or browse to the "drupal_sprint_package" directory.
+Extract the drupal_sprint_package.RELEASE.zip file, and open or browse the contents. This is the sprint package directory.
 
-Extract the quicksprint_thirdparty_installs.RELEASE.zip if downloaded, and open or browse to the extracted directory (also called "drupal_sprint_package" or "drupal_sprint_package 2")
+Extract the quicksprint_thirdparty_installs.RELEASE.zip if downloaded, and open or browse the contents and find the /installs folder. This is the third party installs directory.
 
 <a name="install"></a>
 ### 3. Install Docker and Other Requirements

--- a/DRUPAL_SPRINTUSER_README.md
+++ b/DRUPAL_SPRINTUSER_README.md
@@ -28,22 +28,25 @@ This directory contains tools to get you started contributing to Drupal:
 
 Use one of the options below to get the files.
 
-* USB Drive - Copy drupal_sprint_package-RELEASE.zip and Docker installer for your Operating System from the USB drive to your Desktop.
+* USB Drive - Copy drupal_sprint_package.RELEASE.zip and Docker installer for your Operating System from the USB drive to your Desktop.
 * ResilioSync - Find the folder/directory that was downloaded and copy its contents to your Desktop.
-* GitHub - Download drupal_sprint_package-RELEASE.zip from https://github.com/drud/quicksprint/releases.
+* GitHub - Download drupal_sprint_package.RELEASE.zip from https://github.com/drud/quicksprint/releases. Also download quicksprint_thirdparty_installs.RELEASE.zip if you need Docker and/or Git.
+
 
 <a name="extract-files"></a>
 ### 2. drupal_sprint_package directory
 
-Extract the drupal_sprint_package-RELEASE.zip file, and open or browse to the "drupal_sprint_package" directory.
+Extract the drupal_sprint_package.RELEASE.zip file, and open or browse to the "drupal_sprint_package" directory.
+
+Extract the quicksprint_thirdparty_installs.RELEASE.zip if downloaded, and open or browse to the extracted directory (also called "drupal_sprint_package" or "drupal_sprint_package 2")
 
 <a name="install"></a>
 ### 3. Install Docker and Other Requirements
 
 #### 3.1 Docker CE or Docker Toolbox
 
-* **Windows users install git:** First, install Git For Windows from the **installs** directory. The version here is newer than you might have on your computer if you already have it, so install if you don't have Git for Windows or have a version less than 2.21.0.
-* **All users:** Find the Docker installer for your Operating System underneath the **installs** directory. It is important to install the version of Docker provided for compatibility with the tools.
+* **Windows users install git:** First, install Git For Windows from the **third party installs** directory. The version here is newer than you might have on your computer if you already have it, so install if you don't have Git for Windows or have a version less than 2.21.0.
+* **All users:** Find the Docker installer for your Operating System underneath the **third party installs** directory. It is important to install the version of Docker provided for compatibility with the tools.
 
  Operating System | Docker Version | Installer
  ---------------- | -------------- | -----------------


### PR DESCRIPTION
Updated documentation to match the current contents of the quicksprint releases directory, where 3rd party tools have been moved into their own download, but also have the name 'drupal_sprint_package' when extracted.