### PR TITLE
Add architecture into ddev download tarballs, required as of v1.16, fixes #182

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ GREEN='\033[32m'
 YELLOW='\033[33m'
 RESET='\033[0m'
 OS=$(uname)
+ARCH=$(arch)
 USER=$(whoami)
 SHACMD=""
 FILEBASE=""
@@ -58,12 +59,12 @@ if [ -z "${QUICKSPRINT_SKIP_IMAGE_INSTALL:-}" ]; then
 fi
 
 TARBALL=""
-case "$OS" in
-    Linux)
-        TARBALL=ddev_tarballs/ddev_linux.${DDEV_VERSION}.tar.gz
+case "$OS/$ARCH" in
+    Linux/x86_64)
+        TARBALL=ddev_tarballs/ddev_linux-amd64.${DDEV_VERSION}.tar.gz
         ;;
-    Darwin)
-        TARBALL=ddev_tarballs/ddev_macos.${DDEV_VERSION}.tar.gz
+    Darwin/i386)
+        TARBALL=ddev_tarballs/ddev_macos-amd64.${DDEV_VERSION}.tar.gz
         ;;
     MINGW64_NT*)
         echo ""

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ case "$OS/$ARCH" in
         # Assume if DDEV_INSTALL_DIR is set that we *do* need ddev on Windows, install it.
         # Otherwise, we'll do the install using the installer below.
         if [ ! -z "${DDEV_INSTALL_DIR:-}" ]; then
-            TARBALL=ddev_tarballs/ddev_windows.${DDEV_VERSION}.tar.gz
+            TARBALL=ddev_tarballs/ddev_windows-amd64.${DDEV_VERSION}.tar.gz
         fi
         ;;
     *)

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -113,7 +113,7 @@ done
 
 pushd ${ddev_tarballs} >/dev/null
 # Download the ddev tarballs if necessary; check to make sure they all have correct sha256.
-for tarball in ddev_macos.$LATEST_VERSION.tar.gz ddev_linux.$LATEST_VERSION.tar.gz ddev_windows.$LATEST_VERSION.tar.gz ddev_windows_installer.$LATEST_VERSION.exe ddev_docker_images.$LATEST_VERSION.tar.xz; do
+for tarball in ddev_macos-amd64.$LATEST_VERSION.tar.gz ddev_linux-amd64.$LATEST_VERSION.tar.gz ddev_windows-amd64.$LATEST_VERSION.tar.gz ddev_windows_installer.$LATEST_VERSION.exe ddev_docker_images.$LATEST_VERSION.tar.xz; do
     shafile="${tarball}.sha256.txt"
 
     if ! [ -f "${tarball}" -a -f "${shafile}" ] ; then

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -25,8 +25,9 @@ QUICKSPRINT_RELEASE=$(git describe --tags --always --dirty)
 
 echo "$QUICKSPRINT_RELEASE" >.quicksprint_release.txt
 
-GIT_LATEST_RELEASE="$(curl -L -s -H 'Accept: application/json' https://github.com/git-for-windows/git/releases/latest | jq -r .tag_name | sed 's/^v//; s/\.windows\.1//;')"
-GIT_DOWNLOAD_URL="https://github.com/git-for-windows/git/releases/download/v${GIT_LATEST_RELEASE}.windows.1/Git-${GIT_LATEST_RELEASE}-64-bit.exe"
+GIT_TAG_NAME=$(curl -L -s -H 'Accept: application/json' https://github.com/git-for-windows/git/releases/latest | jq -r .tag_name)
+GIT_LATEST_RELEASE="$(echo $GIT_TAG_NAME | sed 's/^v//; s/\.windows//')"
+GIT_DOWNLOAD_URL="https://github.com/git-for-windows/git/releases/download/${GIT_TAG_NAME}/Git-${GIT_LATEST_RELEASE}-64-bit.exe"
 
 DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/42716/Docker%20Desktop%20Installer.exe ${GIT_DOWNLOAD_URL}"
 

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -24,7 +24,7 @@ ddev exec  "git fetch && git stash save ${STASHNAME} && git checkout origin/${ta
 ddev composer config discard-changes true
 ddev composer install --no-interaction
 ddev exec "( git checkout composer.json && (git stash show ${STASHNAME} 2>/dev/null && git stash apply ${STASHNAME} || true) )"
-ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
+ddev exec drush8 si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
 set +x
 popd >/dev/null
 echo "Switched to ${target_branch}"

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -46,8 +46,8 @@ printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
 ddev composer install
 ddev exec "git checkout /var/www/html/composer.*"
 
-printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
-ddev exec "drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time'"
+printf "${YELLOW}Running 'drush8 si' to install drupal.${RESET}...\n"
+ddev exec "drush8 si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time'"
 printf "${RESET}"
 ddev describe
 

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -61,7 +61,7 @@ function teardown {
     NAME=$(echo ${DESCRIBE} | jq -r ".raw.name")
     HTTP_PORT=$(echo ${DESCRIBE} | jq -r ".raw.router_http_port")
     URL="http://${DHOST}:${HTTP_PORT}"
-    CURL="curl -lL -s --fail -H 'Host: ${NAME}.ddev.site' --silent --output /dev/null --url $URL"
+    CURL="curl -lL -s --fail -H 'Host: ${NAME}.ddev.site' --silent --output /dev/null --url $URL || (rv=$? && ( curl -I -H 'Host: ${NAME}.ddev.site' $URL; exit $rv ))"
     echo "# curl: $CURL" >&3
     ${CURL}
 

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -61,14 +61,12 @@ function teardown {
     NAME=$(echo ${DESCRIBE} | jq -r ".raw.name")
     HTTP_PORT=$(echo ${DESCRIBE} | jq -r ".raw.router_http_port")
     URL="http://${DHOST}:${HTTP_PORT}"
-    CURL="curl -lL -s --fail -H 'Host: ${NAME}.ddev.site' --silent --output /dev/null --url $URL || ( export rv=$? && ( curl -I -H 'Host: ${NAME}.ddev.site' $URL; exit $rv ))"
-    echo "# curl: $CURL" >&3
-    ${CURL}
+    curl -I -H "Host: ${NAME}.ddev.site" http://127.0.0.1:8080 | tee /tmp/quicksprint_test_base_curl.out | grep 'HTTP/1.1 200'
 
     echo "# Testing switch_branch.sh"
-    cd ..
+    cd ${SPRINTDIR}/${SPRINT_NAME}
     ./switch_branch.sh "8.9.x"
-    echo "# Testing curl reachability for ${NAME}.ddev.site" >&3
-    echo "# curl: $CURL" >&3
-    ${CURL}
+    echo "# Testing curl reachability for switch_branch ${NAME}.ddev.site" >&3
+    curl -I -H "Host: ${NAME}.ddev.site" http://127.0.0.1:8080 | tee /tmp/quicksprint_test_switch_branch_curl.out | grep 'HTTP/1.1 200'
+
 }

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -61,7 +61,7 @@ function teardown {
     NAME=$(echo ${DESCRIBE} | jq -r ".raw.name")
     HTTP_PORT=$(echo ${DESCRIBE} | jq -r ".raw.router_http_port")
     URL="http://${DHOST}:${HTTP_PORT}"
-    CURL="curl -lL -s --fail -H 'Host: ${NAME}.ddev.site' --silent --output /dev/null --url $URL || (rv=$? && ( curl -I -H 'Host: ${NAME}.ddev.site' $URL; exit $rv ))"
+    CURL="curl -lL -s --fail -H 'Host: ${NAME}.ddev.site' --silent --output /dev/null --url $URL || ( export rv=$? && ( curl -I -H 'Host: ${NAME}.ddev.site' $URL; exit $rv ))"
     echo "# curl: $CURL" >&3
     ${CURL}
 


### PR DESCRIPTION
#182: ddev downloads are now packaged for arm64 and amd64 architectures. The assumption here in quicksprint was always just amd64. Change to just download amd64, which will do us for a while.

As a result, the nightly build was failing.

After this goes in, we'll need to build a new release.

* Add architecture into names of tarballs used for ddev
* Use drush8 to do `drush si` because drush launcher doing it resulted in an out-of-memory kill of the drush process, see https://github.com/drush-ops/drush-launcher/issues/82
* git-for-windows download URL changed, fixed at least temporarily. Link rot in the way they built the link for a point-point release. It may fail in the future. 
* Minor improvements to tests in installation.bats