### PR TITLE
Update SPRINT_BRANCH=9.2.x for Dec 2020

### DIFF
--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 # Base checkout should be latest major-minor version branch
-SPRINT_BRANCH=9.1.x
+SPRINT_BRANCH=9.2.x
 
 # This makes git-bash actually try to create symlinks.
 # Use developer mode in Windows 10 so this doesn't require admin privs.

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-SPRINT_BRANCH=9.1.x
+SPRINT_BRANCH=9.2.x
 
 RED='\033[31m'
 GREEN='\033[32m'

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -5,7 +5,7 @@
 
 function setup {
     echo "# setup beginning" >&3
-    export SPRINT_BRANCH=9.1.x
+    export SPRINT_BRANCH=9.2.x
 
     export SPRINTDIR=~/sprint
     # DRUD_NONINTERACTIVE causes ddev not to try to use sudo and add the hostname


### PR DESCRIPTION
Drupal 9.1 will be released before next Drupalcon, so we should be on SPRINT_BRANCH=9.2.x