### PR TITLE
[DO NOT PULL] TEST ONLY use drush (launcher) instead of drush8

### DIFF
--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -24,7 +24,7 @@ ddev exec  "git fetch && git stash save ${STASHNAME} && git checkout origin/${ta
 ddev composer config discard-changes true
 ddev composer install --no-interaction
 ddev exec "( git checkout composer.json && (git stash show ${STASHNAME} 2>/dev/null && git stash apply ${STASHNAME} || true) )"
-ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
+ddev exec drush si -vvv --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
 set +x
 popd >/dev/null
 echo "Switched to ${target_branch}"

--- a/sprint/switch_branch.sh
+++ b/sprint/switch_branch.sh
@@ -24,7 +24,7 @@ ddev exec  "git fetch && git stash save ${STASHNAME} && git checkout origin/${ta
 ddev composer config discard-changes true
 ddev composer install --no-interaction
 ddev exec "( git checkout composer.json && (git stash show ${STASHNAME} 2>/dev/null && git stash apply ${STASHNAME} || true) )"
-ddev exec drush8 si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
+ddev exec drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time!'
 set +x
 popd >/dev/null
 echo "Switched to ${target_branch}"

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -46,8 +46,8 @@ printf "${YELLOW}Running 'ddev composer install'${RESET}...\n"
 ddev composer install
 ddev exec "git checkout /var/www/html/composer.*"
 
-printf "${YELLOW}Running 'drush8 si' to install drupal.${RESET}...\n"
-ddev exec "drush8 si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time'"
+printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
+ddev exec "drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time'"
 printf "${RESET}"
 ddev describe
 

--- a/start_sprint.sh
+++ b/start_sprint.sh
@@ -47,7 +47,7 @@ ddev composer install
 ddev exec "git checkout /var/www/html/composer.*"
 
 printf "${YELLOW}Running 'drush si' to install drupal.${RESET}...\n"
-ddev exec "drush si --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time'"
+ddev exec "drush si -vvv --yes standard --account-pass=admin --db-url=mysql://db:db@db/db --site-name='Drupal Contribution Time'"
 printf "${RESET}"
 ddev describe
 


### PR DESCRIPTION
This is a simple demonstration to see if we can recreate the failure when drush launcher is used for `drush si` instead of using drush8 directly. Upstream issue is https://github.com/drush-ops/drush-launcher/issues/82