### PR TITLE
Change docker desktop download locations, fixes #193

### DIFF
--- a/.buildkite/darwin_amd64.yaml
+++ b/.buildkite/darwin_amd64.yaml
@@ -1,0 +1,6 @@
+steps:
+- command: ".buildkite/test.sh"
+  label: "package and test"
+  agents:
+  - "os=macos"
+  - "architecture=amd64"

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -14,7 +14,7 @@ darwin)
 
     ;;
 windows)
-    choco upgrade -y mkcert ddev composer php
+    choco upgrade -y mkcert ddev
     composer self-update
     ;;
 esac

--- a/.buildkite/windows_amd64.yml
+++ b/.buildkite/windows_amd64.yml
@@ -1,0 +1,7 @@
+steps:
+- command: ".buildkite/test.cmd"
+  label: "package and test"
+  agents:
+  - "os=windows"
+  - "dockertype=dockerforwindows"
+  - "architecture=amd64"

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ if [ -z "${QUICKSPRINT_SKIP_IMAGE_INSTALL:-}" ]; then
 fi
 
 TARBALL=""
-case "$OS/$ARCH" in
+case "${OS}/${ARCH}" in
     Linux/x86_64)
         TARBALL=ddev_tarballs/ddev_linux-amd64.${DDEV_VERSION}.tar.gz
         ;;
@@ -75,7 +75,7 @@ case "$OS/$ARCH" in
         fi
         ;;
     *)
-        printf "${RED}No ddev binary is available for ${OS}${RESET}\n"
+        printf "${RED}No ddev binary is available for ${OS}/${ARCH}${RESET}\n"
         exit 2
         ;;
 

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -29,7 +29,7 @@ GIT_TAG_NAME=$(curl -L -s -H 'Accept: application/json' https://github.com/git-f
 GIT_LATEST_RELEASE="$(echo $GIT_TAG_NAME | sed 's/^v//; s/\.windows//')"
 GIT_DOWNLOAD_URL="https://github.com/git-for-windows/git/releases/download/${GIT_TAG_NAME}/Git-${GIT_LATEST_RELEASE}-64-bit.exe"
 
-DOWNLOAD_URLS="https://download.docker.com/mac/stable/Docker.dmg https://download.docker.com/win/stable/42716/Docker%20Desktop%20Installer.exe ${GIT_DOWNLOAD_URL}"
+DOWNLOAD_URLS="https://desktop.docker.com/mac/stable/Docker.dmg https://desktop.docker.com/win/stable/Docker%20Desktop%20Installer.exe ${GIT_DOWNLOAD_URL}"
 
 RED='\033[31m'
 GREEN='\033[32m'


### PR DESCRIPTION
Docker has changed the download locations for docker desktop and orphaned the original ones, #193, so we end up with older versions bundled with quicksprint.

This changes to the current download links.

I also had to do some buildkite maintenance for this. Since the last round here architecture has become very important, so the testbots are selected by both OS and architecture.