### PR TITLE
Update Circleci testing to current Ubuntu image

### DIFF
--- a/.circleci/circle_vm_setup.sh
+++ b/.circleci/circle_vm_setup.sh
@@ -5,30 +5,14 @@ set -x
 
 # Basic tools
 
-v=php7.3
+v=php7.4
 sudo add-apt-repository -y ppa:ondrej/php
 sudo apt-get update -qq
-sudo apt-get install -y -qq jq realpath zip ${v} ${v}-bcmath ${v}-curl ${v}-cgi ${v}-cli ${v}-common ${v}-fpm ${v}-gd ${v}-intl ${v}-json ${v}-mysql ${v}-mbstring  ${v}-opcache ${v}-soap ${v}-readline ${v}-xdebug ${v}-xml ${v}-xmlrpc ${v}-zip;
-
-# Remove any existing docker
-sudo apt-get remove docker docker-engine docker.io
-sudo apt-get install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-sudo apt-get update -qq
-sudo apt-get install -qq docker-ce
+sudo apt-get install -y -qq coreutils jq zip ${v} ${v}-bcmath ${v}-curl ${v}-cgi ${v}-cli ${v}-common ${v}-fpm ${v}-gd ${v}-intl ${v}-json ${v}-mysql ${v}-mbstring  ${v}-opcache ${v}-soap ${v}-readline ${v}-xdebug ${v}-xml ${v}-xmlrpc ${v}-zip;
 
 sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 sudo php -r "unlink('composer-setup.php');"
-
 
 if [ ! -d /home/linuxbrew/.linuxbrew/bin ] ; then
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
@@ -38,8 +22,8 @@ echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc
 
 . ~/.bashrc
 
-brew update && brew tap drud/ddev
-brew install mkcert ddev docker-compose
+brew update
+brew install mkcert drud/ddev/ddev
 
 # install recent bats bash testing framework
 BATS_TAG=v1.1.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
   "package_build":
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/quicksprint
     environment:
       TERM: vt100
@@ -24,7 +24,7 @@ jobs:
         - tmp
   "test_package":
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/quicksprint
     environment:
       TERM: vt100
@@ -40,7 +40,7 @@ jobs:
 
   "artifacts":
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202101-01
     working_directory: ~/quicksprint
     environment:
       ARTIFACTS: /home/circleci/artifacts


### PR DESCRIPTION
I saw some nightly build failures and noticed when debugging that they were using Ubuntu 16.04, which just went out of support. Should be running Ubuntu 20.04 anyway.

The Ubuntu 20.04 image contains docker, so we don't need to be doing that.