### PR TITLE
Support M1 mac (and arm64 linux) in quicksprint, fixes #199

### DIFF
--- a/.buildkite/darwin_arm64.yaml
+++ b/.buildkite/darwin_arm64.yaml
@@ -1,6 +1,6 @@
 steps:
 - command: ".buildkite/test.sh"
-  label: "package and test amd64"
+  label: "package and test arm64"
   agents:
   - "os=macos"
-  - "architecture=amd64"
+  - "architecture=arm64"

--- a/install.sh
+++ b/install.sh
@@ -63,8 +63,14 @@ case "${OS}/${ARCH}" in
     Linux/x86_64)
         TARBALL=ddev_tarballs/ddev_linux-amd64.${DDEV_VERSION}.tar.gz
         ;;
+    Linux/arm64)
+        TARBALL=ddev_tarballs/ddev_linux-arm64.${DDEV_VERSION}.tar.gz
+        ;;
     Darwin/i386)
         TARBALL=ddev_tarballs/ddev_macos-amd64.${DDEV_VERSION}.tar.gz
+        ;;
+    Darwin/arm64)
+        TARBALL=ddev_tarballs/ddev_macos-arm64.${DDEV_VERSION}.tar.gz
         ;;
     MINGW64_NT*)
         echo ""

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ YELLOW='\033[33m'
 RESET='\033[0m'
 OS=$(uname)
 ARCH=$(arch)
+if [ ${ARCH} = "i386" ] || [ ${ARCH} = "x86_64" ]; then ARCH=amd64; fi
 USER=$(whoami)
 SHACMD=""
 FILEBASE=""
@@ -50,9 +51,9 @@ printf "Installing docker images for ddev to use...\n"
 # Allow faster turnaround on testing by export QUICKSPRINT_SKIP_IMAGE_INSTALL=true
 if [ -z "${QUICKSPRINT_SKIP_IMAGE_INSTALL:-}" ]; then
     if command -v xzcat >/dev/null; then
-        xzcat ddev_tarballs/ddev_docker_images*.tar.xz | docker load
+        xzcat ddev_tarballs/ddev_docker_images.${ARCH}.*.tar.xz | docker load
     elif [[ "$OS" == "Darwin" ]]; then
-        gzip -dc ddev_tarballs/ddev_docker_images*.tar.xz | docker load
+        gzip -dc ddev_tarballs/ddev_docker_images.${ARCH}.*.tar.xz | docker load
     else
         printf "${YELLOW}Unable to load ddev_docker_images. They will load at first 'ddev start'.${RESET}\n"
     fi
@@ -60,11 +61,17 @@ fi
 
 TARBALL=""
 case "${OS}/${ARCH}" in
-    Linux/x86_64)
+    Linux/amd64)
         TARBALL=ddev_tarballs/ddev_linux-amd64.${DDEV_VERSION}.tar.gz
         ;;
-    Darwin/i386)
+    Linux/arm64)
+        TARBALL=ddev_tarballs/ddev_linux-arm64.${DDEV_VERSION}.tar.gz
+        ;;
+    Darwin/amd64)
         TARBALL=ddev_tarballs/ddev_macos-amd64.${DDEV_VERSION}.tar.gz
+        ;;
+    Darwin/arm64)
+        TARBALL=ddev_tarballs/ddev_macos-arm64.${DDEV_VERSION}.tar.gz
         ;;
     MINGW64_NT*)
         echo ""

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -28,8 +28,7 @@ echo "$QUICKSPRINT_RELEASE" >.quicksprint_release.txt
 GIT_TAG_NAME=$(curl -L -s -H 'Accept: application/json' https://github.com/git-for-windows/git/releases/latest | jq -r .tag_name)
 GIT_LATEST_RELEASE="$(echo $GIT_TAG_NAME | sed 's/^v//; s/\.windows//')"
 GIT_DOWNLOAD_URL="https://github.com/git-for-windows/git/releases/download/${GIT_TAG_NAME}/Git-${GIT_LATEST_RELEASE}-64-bit.exe"
-
-DOWNLOAD_URLS="https://desktop.docker.com/mac/stable/Docker.dmg https://desktop.docker.com/win/stable/Docker%20Desktop%20Installer.exe ${GIT_DOWNLOAD_URL}"
+DOWNLOAD_URLS="${GIT_DOWNLOAD_URL}"
 
 RED='\033[31m'
 GREEN='\033[32m'
@@ -98,9 +97,15 @@ while true; do
                 mkdir -p installs
                 pushd installs >/dev/null
                 for download_url in ${DOWNLOAD_URLS}; do
-                    echo "Downloading ${download_url##*/} from ${download_url}"
+                    echo "Downloading ${download_url##*/} from ${download_url}..."
                     curl -sSL -O ${download_url}
                 done
+                for arch in amd64 arm64; do
+                  echo "Downloading Docker desktop (macOS ${arch})..."
+                  curl -sSL -o docker_desktop_${arch}.dmg https://desktop.docker.com/mac/main/${arch}/Docker.dmg
+                done
+                echo "Downloading Docker desktop (Windows)..."
+                curl -sSL -O https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe
                 popd >/dev/null
                 break;;
 

--- a/package_drupal_script.sh
+++ b/package_drupal_script.sh
@@ -62,7 +62,7 @@ ddev_tarballs="${STAGING_DIR}/ddev_tarballs"
 mkdir -p ${ddev_tarballs}
 
 # Remove anything in staging directory except ddev_tarballs.
-# Chmod as on WIndows read-only stuff is often unremoveable
+# Chmod as on Windows read-only stuff is often unremoveable
 chmod -R u+w ${STAGING_DIR}/{*.md,install.sh,sprint,start_sprint.sh} 2>/dev/null || true
 rm -rf ${STAGING_DIR}/{*.md,install.sh,sprint,start_sprint.sh}
 # Remove anything in ddev_tarballs that is not the latest version
@@ -114,7 +114,7 @@ done
 
 pushd ${ddev_tarballs} >/dev/null
 # Download the ddev tarballs if necessary; check to make sure they all have correct sha256.
-for tarball in ddev_macos-amd64.$LATEST_VERSION.tar.gz ddev_linux-amd64.$LATEST_VERSION.tar.gz ddev_windows-amd64.$LATEST_VERSION.tar.gz ddev_windows_installer.$LATEST_VERSION.exe ddev_docker_images.$LATEST_VERSION.tar.xz; do
+for tarball in ddev_macos-amd64.$LATEST_VERSION.tar.gz ddev_macos-arm64.$LATEST_VERSION.tar.gz ddev_linux-amd64.$LATEST_VERSION.tar.gz ddev_linux-arm64.$LATEST_VERSION.tar.gz ddev_windows-amd64.$LATEST_VERSION.tar.gz ddev_windows_installer.$LATEST_VERSION.exe ddev_docker_images.arm64.$LATEST_VERSION.tar.xz ddev_docker_images.amd64.$LATEST_VERSION.tar.xz; do
     shafile="${tarball}.sha256.txt"
 
     if ! [ -f "${tarball}" -a -f "${shafile}" ] ; then
@@ -126,7 +126,7 @@ for tarball in ddev_macos-amd64.$LATEST_VERSION.tar.gz ddev_linux-amd64.$LATEST_
 done
 popd >/dev/null
 
-# clone or refresh d8 clone
+# clone or refresh drupal clone
 mkdir -p sprint
 git clone --config core.autocrlf=false --config core.eol=lf --config core.filemode=false --quiet https://git.drupalcode.org/project/drupal.git ${STAGING_DIR}/sprint/drupal -b ${SPRINT_BRANCH}
 pushd ${STAGING_DIR}/sprint/drupal >/dev/null

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -70,3 +70,37 @@ function teardown {
     curl -I -H "Host: ${NAME}.ddev.site" http://127.0.0.1:8080 | tee /tmp/quicksprint_test_switch_branch_curl.out | grep 'HTTP/1.1 200'
 
 }
+
+@test "verify correct architecture for macOS ddev binary" {
+  if [ "$(uname -s)" != "Darwin" ]; then skip "Skipping because not on macOS"; fi
+
+  arch=$(arch)
+  case ${arch} in
+  arm64)
+    file $(which ddev) | grep arm64
+    ;;
+  i386)
+    file $(which ddev) | grep x86_64
+    ;;
+  default)
+    false
+  esac
+}
+
+@test "verify correct architecture for macOS pulled images" {
+  if [ "$(uname -s)" != "Darwin" ]; then skip "Skipping because not on macOS"; fi
+
+  webimage="$(ddev version | awk '/ddev-webserver/ { print $2}')"
+  image_arch="$(docker image inspect --format "{{json .Architecture }}" ${webimage})"
+  arch=$(arch)
+  case ${arch} in
+  arm64)
+    [ ${image_arch} = '"arm64"' ]
+    ;;
+  i386)
+    [ ${image_arch} = '"amd64"' ]
+    ;;
+  default)
+    false
+  esac
+}

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -7,6 +7,8 @@ function setup {
     echo "# setup beginning" >&3
     export SPRINT_BRANCH=9.3.x
 
+    ddev poweroff
+
     export SPRINTDIR=~/sprint
     # DRUD_NONINTERACTIVE causes ddev not to try to use sudo and add the hostname
     export DRUD_NONINTERACTIVE=true

--- a/tests/installation.bats
+++ b/tests/installation.bats
@@ -104,5 +104,6 @@ function teardown {
     ;;
   default)
     false
+    ;;
   esac
 }

--- a/tests/test_drupal_quicksprint.sh
+++ b/tests/test_drupal_quicksprint.sh
@@ -21,6 +21,7 @@ export PATH="$PATH:/usr/local/bin"
 tests/sanetestbot.sh || ( echo "sanetestbot.sh failed, test machine is not ready for duty" && exit 1 )
 
 function cleanup {
+    ddev poweroff
     rm -rf /tmp/drupal_sprint_package "$DDEV_INSTALL_DIR"
     if [ ! -z "${SOURCE_TARBALL_LOCATION:-}" ] ; then rm -f ${SOURCE_TARBALL_LOCATION:-nopedontrm}; fi
 }
@@ -45,9 +46,6 @@ fi
 
 # Run install.sh
 (cd "$UNTARRED_PACKAGE" && printf 'y\ny\n' | ./install.sh) || ( echo "Failed to install.sh" && exit 4 )
-
-# Stop any running ddev instances
-ddev poweroff
 
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"


### PR DESCRIPTION
- [x] Download named tarballs for amd64 and arm64 images (separated out)
- [x] Download named tarballs for Linux arm64 and Mac arm64 ddev binary
- [x] Detect the correct ddev binary and docker image package to use at build time
- [x] Add tests to make sure this works on arm64
- [x] Add testing capability on mac M1 so the M1 version gets run

